### PR TITLE
Allow additional libXmlConstants in Client and Response for decoding

### DIFF
--- a/docs/book/client.md
+++ b/docs/book/client.md
@@ -334,6 +334,7 @@ $client->setLibXmlConstants(LIBXML_PARSEHUGE);
 ```
 
 Multiple constants can be used by using the bitwise OR operator:
+
 ```php
 $client->setLibXmlConstants(LIBXML_PARSEHUGE | LIBXML_PEDANTIC);
 ```

--- a/docs/book/client.md
+++ b/docs/book/client.md
@@ -324,3 +324,16 @@ The `setHttpClient()` is particularly useful for unit testing. When combined
 with `Laminas\Http\Client\Adapter\Test`, remote services can be mocked out for
 testing. See the unit tests for `Laminas\XmlRpc\Client` for examples of how to do
 this.
+
+## Using additional libXml constants
+Additional libXml constants can be specified using the `setLibXmlConstants()` instance method. Available constants can be found in the [PHP reference manual](https://www.php.net/manual/en/libxml.constants.php).
+
+```php
+$client = new Laminas\XmlRpc\Client('http://www.advogato.org/XMLRPC');
+$client->setLibXmlConstants(LIBXML_PARSEHUGE);
+```
+
+Multiple constants can be used by using the bitwise OR operator:
+```php
+$client->setLibXmlConstants(LIBXML_PARSEHUGE | LIBXML_PEDANTIC);
+```

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -178,10 +178,11 @@ abstract class AbstractValue
      *
      * @param  mixed $value
      * @param  Laminas\XmlRpc\Value::constant $type
+     * @param  int $libXmlConstants
      * @throws Exception\ValueException
      * @return AbstractValue
      */
-    public static function getXmlRpcValue($value, $type = self::AUTO_DETECT_TYPE)
+    public static function getXmlRpcValue($value, $type = self::AUTO_DETECT_TYPE, $libXmlConstants = 0)
     {
         switch ($type) {
             case self::AUTO_DETECT_TYPE:
@@ -190,7 +191,7 @@ abstract class AbstractValue
 
             case self::XML_STRING:
                 // Parse the XML string given in $value and get the XML-RPC value in it
-                return static::xmlStringToNativeXmlRpc($value);
+                return static::xmlStringToNativeXmlRpc($value, $libXmlConstants);
 
             case self::XMLRPC_TYPE_I4:
                 // fall through to the next case
@@ -323,14 +324,15 @@ abstract class AbstractValue
      *
      * @param string|\SimpleXMLElement $xml A SimpleXMLElement object represent the XML string
      * It can be also a valid XML string for conversion
+     * @param int $libXmlConstants
      *
      * @throws Exception\ValueException
      * @return \Laminas\XmlRpc\AbstractValue
      * @static
      */
-    protected static function xmlStringToNativeXmlRpc($xml)
+    protected static function xmlStringToNativeXmlRpc($xml, $libXmlConstants = 0)
     {
-        static::createSimpleXMLElement($xml);
+        static::createSimpleXMLElement($xml, $libXmlConstants);
 
         static::extractTypeAndValue($xml, $type, $value);
 
@@ -418,14 +420,14 @@ abstract class AbstractValue
         return $xmlrpcValue;
     }
 
-    protected static function createSimpleXMLElement(&$xml)
+    protected static function createSimpleXMLElement(&$xml, $libXmlConstants = 0)
     {
         if ($xml instanceof SimpleXMLElement) {
             return;
         }
 
         try {
-            $xml = new SimpleXMLElement($xml);
+            $xml = new SimpleXMLElement($xml, $libXmlConstants);
         } catch (\Exception $e) {
             // The given string is not a valid XML
             throw new Exception\ValueException(

--- a/src/Client.php
+++ b/src/Client.php
@@ -60,6 +60,12 @@ class Client implements ServerClient
     protected $skipSystemLookup = false;
 
     /**
+     * Additional libxml constants to use for decoding
+     * @var int
+     */
+    protected $libXmlConstants = 0;
+
+    /**
      * Create a new XML-RPC client to a remote server
      *
      * @param  string $server      Full address of the XML-RPC service
@@ -156,6 +162,30 @@ class Client implements ServerClient
     }
 
     /**
+     * Retrieve additional libxml constants to use for decoding
+     *
+     * @return int
+     */
+    public function getLibXmlConstants()
+    {
+        return $this->libXmlConstants;
+    }
+
+    /**
+     * Set additional libxml constants to use for decoding
+     *
+     * @param int $libXmlConstants
+     *
+     * @return \Laminas\XmlRpc\Client
+     */
+    public function setLibXmlConstants($libXmlConstants)
+    {
+        $this->libXmlConstants = $libXmlConstants;
+
+        return $this;
+    }
+
+    /**
      * Set skip system lookup flag
      *
      * @param  bool $flag
@@ -238,6 +268,7 @@ class Client implements ServerClient
 
         if ($response === null) {
             $response = new Response();
+            $response->setLibXmlConstants($this->libXmlConstants);
         }
 
         $this->lastResponse = $response;

--- a/src/Response.php
+++ b/src/Response.php
@@ -42,6 +42,12 @@ class Response
     protected $fault = null;
 
     /**
+     * Additional libxml constants to use for decoding
+     * @var int
+     */
+    protected $libXmlConstants = 0;
+
+    /**
      * Constructor
      *
      * Can optionally pass in the return value and type hinting; otherwise, the
@@ -91,6 +97,30 @@ class Response
     {
         $this->return = $value;
         $this->type = (string) $type;
+    }
+
+    /**
+     * Retrieve additional libxml constants to use for decoding
+     *
+     * @return int
+     */
+    public function getLibXmlConstants()
+    {
+        return $this->libXmlConstants;
+    }
+
+    /**
+     * Set additional libxml constants to use for decoding
+     *
+     * @param int $libXmlConstants
+     *
+     * @return \Laminas\XmlRpc\Response
+     */
+    public function setLibXmlConstants($libXmlConstants)
+    {
+        $this->libXmlConstants = $libXmlConstants;
+
+        return $this;
     }
 
     /**
@@ -153,7 +183,7 @@ class Response
         }
 
         try {
-            $xml = XmlSecurity::scan($response);
+            $xml = XmlSecurity::scan($response, null, $this->libXmlConstants);
         } catch (\Laminas\Xml\Exception\RuntimeException $e) {
             $this->fault = new Fault(651);
             $this->fault->setEncoding($this->getEncoding());

--- a/src/Response.php
+++ b/src/Response.php
@@ -210,7 +210,7 @@ class Response
                 throw new Exception\ValueException('Missing XML-RPC value in XML');
             }
             $valueXml = $xml->params->param->value->asXML();
-            $value = AbstractValue::getXmlRpcValue($valueXml, AbstractValue::XML_STRING);
+            $value = AbstractValue::getXmlRpcValue($valueXml, AbstractValue::XML_STRING, $this->libXmlConstants);
         } catch (Exception\ValueException $e) {
             $this->fault = new Fault(653);
             $this->fault->setEncoding($this->getEncoding());


### PR DESCRIPTION
Allow additional libXmlConstants in `Client` and `Response` for decoding.

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | yes(?)
| QA            | no

### Description
I need to use `LIBXML_PARSEHUGE` for decoding some responses. A simple addition to the `Client` and `Response` classes makes this possible with very little changes to the code.

This can then be used by calling `setLibXmlConstants()` on the `Client` object.
```
$xmlRpcClient->setLibXmlConstants(LIBXML_PARSEHUGE);
[...]
$response = $xmlRpcClient->call($method, $data);
```

