### PR TITLE
updated for PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,12 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-        - CS_CHECK=true
-        - TEST_COVERAGE=true
     - php: 7.3
       env:
         - DEPS=lowest
@@ -30,6 +22,12 @@ matrix:
       env:
         - DEPS=lowest
     - php: 7.4
+      env:
+        - DEPS=latest
+    - php: 8.0
+      env:
+        - DEPS=lowest
+    - php: 8.0
       env:
         - DEPS=latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     - php: 7.3
       env:
         - DEPS=latest
+        - CS_CHECK=true
+        - TEST_COVERAGE=true
     - php: 7.4
       env:
         - DEPS=lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - COMPOSER_ARGS="--no-interaction"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,16 @@
     },
     "extra": {
     },
+    "repositories": [
+      {
+        "type": "git",
+        "url": "https://github.com/bfoosness/laminas-math.git"
+      }
+    ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-http": "^2.5.4",
-        "laminas/laminas-math": "^2.7 || ^3.0",
+        "laminas/laminas-math": "dev-php-8.0",
         "laminas/laminas-server": "^2.7",
         "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-xml": "^1.0.2",
@@ -31,7 +37,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.3"
     },
     "suggest": {
         "laminas/laminas-cache": "To support Laminas\\XmlRpc\\Server\\Cache usage"

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": "^7.3 || ~8.0.0",
         "laminas/laminas-http": "^2.5.4",
         "laminas/laminas-math": "dev-php-8.0",
-        "laminas/laminas-server": "^2.7",
+        "laminas/laminas-server": "^2.9.1",
         "laminas/laminas-stdlib": "^3.2.1",
         "laminas/laminas-xml": "^1.0.2",
         "laminas/laminas-zendframework-bridge": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,12 @@
     ],
     "require": {
         "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-http": "^2.5.4",
+        "laminas/laminas-http": "^2.14",
         "laminas/laminas-math": "dev-php-8.0",
-        "laminas/laminas-server": "^2.7",
-        "laminas/laminas-stdlib": "^3.2.1",
-        "laminas/laminas-xml": "^1.0.2",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-server": "^2.9",
+        "laminas/laminas-stdlib": "^3.3.1",
+        "laminas/laminas-xml": "^1.3",
+        "laminas/laminas-zendframework-bridge": "^1.1"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
         "php": "^7.3 || ~8.0.0",
         "laminas/laminas-http": "^2.5.4",
         "laminas/laminas-math": "dev-php-8.0",
-        "laminas/laminas-server": "^2.9",
-        "laminas/laminas-stdlib": "^3.3.1",
-        "laminas/laminas-xml": "^1.3",
-        "laminas/laminas-zendframework-bridge": "^1.1"
+        "laminas/laminas-server": "^2.7",
+        "laminas/laminas-stdlib": "^3.2.1",
+        "laminas/laminas-xml": "^1.0.2",
+        "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     ],
     "require": {
         "php": "^7.3 || ~8.0.0",
-        "laminas/laminas-http": "^2.14",
+        "laminas/laminas-http": "^2.5.4",
         "laminas/laminas-math": "dev-php-8.0",
         "laminas/laminas-server": "^2.9",
         "laminas/laminas-stdlib": "^3.3.1",

--- a/src/Request.php
+++ b/src/Request.php
@@ -281,7 +281,14 @@ class Request
             return false;
         }
 
-        $xmlErrorsFlag = libxml_use_internal_errors(true);
+        // @see Laminas-12293 - disable external entities for security purposes for < PHP 8
+        $isOldPhp = PHP_MAJOR_VERSION < 8;
+
+        if ($isOldPhp) {
+            $loadEntities  = libxml_disable_entity_loader(true);
+            $xmlErrorsFlag = libxml_use_internal_errors(true);
+        }
+
         try {
             $dom = new DOMDocument;
             $dom->loadXML($request);
@@ -295,11 +302,13 @@ class Request
             ErrorHandler::start();
             $xml   = simplexml_import_dom($dom);
             $error = ErrorHandler::stop();
+            $isOldPhp ? libxml_disable_entity_loader($loadEntities) : null;
             libxml_use_internal_errors($xmlErrorsFlag);
         } catch (\Exception $e) {
             // Not valid XML
             $this->fault = new Fault(631);
             $this->fault->setEncoding($this->getEncoding());
+            $isOldPhp ? libxml_disable_entity_loader($loadEntities) : null;
             libxml_use_internal_errors($xmlErrorsFlag);
             return false;
         }

--- a/src/Request.php
+++ b/src/Request.php
@@ -286,8 +286,8 @@ class Request
 
         if ($isOldPhp) {
             $loadEntities  = libxml_disable_entity_loader(true);
-            $xmlErrorsFlag = libxml_use_internal_errors(true);
         }
+        $xmlErrorsFlag = libxml_use_internal_errors(true);
 
         try {
             $dom = new DOMDocument;

--- a/src/Request.php
+++ b/src/Request.php
@@ -281,8 +281,6 @@ class Request
             return false;
         }
 
-        // @see Laminas-12293 - disable external entities for security purposes
-        $loadEntities  = libxml_disable_entity_loader(true);
         $xmlErrorsFlag = libxml_use_internal_errors(true);
         try {
             $dom = new DOMDocument;
@@ -297,13 +295,11 @@ class Request
             ErrorHandler::start();
             $xml   = simplexml_import_dom($dom);
             $error = ErrorHandler::stop();
-            libxml_disable_entity_loader($loadEntities);
             libxml_use_internal_errors($xmlErrorsFlag);
         } catch (\Exception $e) {
             // Not valid XML
             $this->fault = new Fault(631);
             $this->fault->setEncoding($this->getEncoding());
-            libxml_disable_entity_loader($loadEntities);
             libxml_use_internal_errors($xmlErrorsFlag);
             return false;
         }


### PR DESCRIPTION
calls to libxml_disable_entity_loader() were removed (no longer necessary)
https://www.php.net/manual/en/migration80.deprecated.php

https://github.com/laminas/laminas-xmlrpc/issues/8