### PR TITLE
Upgrade laminas-coding-standard to 2.2

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,8 +1,5 @@
 {
     "extensions": [
         "gmp"
-    ],
-    "exclude": [
-        {"name": "PHPUnit on PHP 7.3 with locked dependencies"}
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.1.0",
         "phpunit/phpunit": "^9.3"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "^7.4 || ~8.0.0",
         "laminas/laminas-http": "^2.5.4",
         "laminas/laminas-math": "^3.3.0",
         "laminas/laminas-server": "^2.9.1",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~2.1.0",
+        "laminas/laminas-coding-standard": "~2.2.1",
         "phpunit/phpunit": "^9.3"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0601a5906b2cd997be109f514f5b874b",
+    "content-hash": "b118caacd7a47b182f61b81b9e47fb1d",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -874,6 +874,76 @@
     ],
     "packages-dev": [
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -944,31 +1014,37 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/d75f1acf615232e108da2d2cf5a7df3e527b8f38",
+                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38",
                 "shasum": ""
             },
             "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
                 "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "php": "^7.3 || ~8.0.0",
+                "slevomat/coding-standard": "^6.4.1",
+                "squizlabs/php_codesniffer": "^3.5.8",
+                "webimpress/coding-standard": "^1.1.6"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -982,7 +1058,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-10-26T07:33:05+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1433,6 +1515,59 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
             "time": "2021-03-17T13:42:18+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^0.9.2",
+                "phing/phing": "^2.16.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.26",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^6.3",
+                "slevomat/coding-standard": "^4.7.2",
+                "symfony/process": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2820,64 +2955,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
+            },
+            "require-dev": {
+                "phing/phing": "2.16.3",
+                "php-parallel-lint/php-parallel-lint": "1.2.0",
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-05T12:39:37+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2890,7 +3059,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -2900,7 +3069,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3032,6 +3201,61 @@
             "time": "2020-07-12T23:59:07+00:00"
         },
         {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-12T12:51:27+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "1.10.0",
             "source": {
@@ -3099,5 +3323,5 @@
         "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f77b6bd3d0c9a50f27ba749d77d9b68b",
+    "content-hash": "e076eaab3b98dce428593cf6899c3513",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -3319,7 +3319,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "^7.4 || ~8.0.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b118caacd7a47b182f61b81b9e47fb1d",
+    "content-hash": "f77b6bd3d0c9a50f27ba749d77d9b68b",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1014,21 +1014,20 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "2.1.4",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38"
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/d75f1acf615232e108da2d2cf5a7df3e527b8f38",
-                "reference": "d75f1acf615232e108da2d2cf5a7df3e527b8f38",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/c953ecb1d37034f4aa326046e2c24a10fe0a2845",
+                "reference": "c953ecb1d37034f4aa326046e2c24a10fe0a2845",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
-                "laminas/laminas-zendframework-bridge": "^1.0",
                 "php": "^7.3 || ~8.0.0",
                 "slevomat/coding-standard": "^6.4.1",
                 "squizlabs/php_codesniffer": "^3.5.8",
@@ -1064,7 +1063,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2020-10-26T07:33:05+00:00"
+            "time": "2021-05-17T17:39:41+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/docs/book/server.md
+++ b/docs/book/server.md
@@ -133,9 +133,9 @@ helps prevent naming collisions between methods served by different classes. As
 an example, the XML-RPC server is expected to server several methods in the
 `system` namespace:
 
-- `system.listMethods`
-- `system.methodHelp`
-- `system.methodSignature`
+* `system.listMethods`
+* `system.methodHelp`
+* `system.methodSignature`
 
 Internally, these map to the methods of the same name in `Laminas\XmlRpc\Server`.
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas Coding Standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,4 +17,8 @@
 
     <!-- Include all rules from the Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard"/>
+
+    <rule ref="WebimpressCodingStandard.NamingConventions.Exception.Suffix">
+        <exclude-pattern>test/Server/TestAsset/Exception*.php</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc;
 
 use DateTime;

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc;
 
 use Laminas\Http;

--- a/src/Client.php
+++ b/src/Client.php
@@ -128,7 +128,6 @@ class Client implements ServerClient
     /**
      * Sets the object used to introspect remote servers
      *
-     * @param  ServerIntrospection
      * @return ServerIntrospection
      */
     public function setIntrospector(ServerIntrospection $introspector)
@@ -278,7 +277,7 @@ class Client implements ServerClient
      */
     public function call($method, $params = [])
     {
-        if (! $this->skipSystemLookup() && ('system.' != substr($method, 0, 7))) {
+        if (! $this->skipSystemLookup() && ('system.' !== substr($method, 0, 7))) {
             // Ensure empty array/struct params are cast correctly
             // If system.* methods are not available, bypass. (Laminas-2978)
             $success = true;
@@ -316,7 +315,7 @@ class Client implements ServerClient
                                 continue;
                             }
                             if (isset($signature['parameters'][$key])) {
-                                if ($signature['parameters'][$key] == $type) {
+                                if ($signature['parameters'][$key] === $type) {
                                     break;
                                 }
                             }

--- a/src/Client/Exception/ExceptionInterface.php
+++ b/src/Client/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Client\Exception;
 
 use Laminas\XmlRpc\Exception\ExceptionInterface as Exception;

--- a/src/Client/Exception/FaultException.php
+++ b/src/Client/Exception/FaultException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Client\Exception;
 
 use Laminas\XmlRpc\Exception;

--- a/src/Client/Exception/HttpException.php
+++ b/src/Client/Exception/HttpException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Client\Exception;
 
 /**

--- a/src/Client/Exception/IntrospectException.php
+++ b/src/Client/Exception/IntrospectException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Client\Exception;
 
 /**

--- a/src/Client/Exception/InvalidArgumentException.php
+++ b/src/Client/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Client\Exception;
 
 use Laminas\XmlRpc\Exception;

--- a/src/Client/Exception/RuntimeException.php
+++ b/src/Client/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Client\Exception;
 
 use Laminas\XmlRpc\Exception;

--- a/src/Client/ServerIntrospection.php
+++ b/src/Client/ServerIntrospection.php
@@ -83,7 +83,7 @@ class ServerIntrospection
             throw new Exception\IntrospectException($error);
         }
 
-        if (count($serverSignatures) != count($methods)) {
+        if (count($serverSignatures) !== count($methods)) {
             $error = 'Bad number of signatures received from multicall';
             throw new Exception\IntrospectException($error);
         }

--- a/src/Client/ServerIntrospection.php
+++ b/src/Client/ServerIntrospection.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Client;
 
 use Laminas\XmlRpc\Client as XMLRPCClient;

--- a/src/Client/ServerIntrospection.php
+++ b/src/Client/ServerIntrospection.php
@@ -9,20 +9,20 @@
 namespace Laminas\XmlRpc\Client;
 
 use Laminas\XmlRpc\Client as XMLRPCClient;
+use Laminas\XmlRpc\Client\ServerProxy;
+
+use function count;
+use function gettype;
+use function is_array;
 
 /**
  * Wraps the XML-RPC system.* introspection methods
  */
 class ServerIntrospection
 {
-    /**
-     * @var \Laminas\XmlRpc\Client\ServerProxy
-     */
-    private $system = null;
+    /** @var ServerProxy */
+    private $system;
 
-    /**
-     * @param \Laminas\XmlRpc\Client $client
-     */
     public function __construct(XMLRPCClient $client)
     {
         $this->system = $client->getProxy('system');
@@ -69,14 +69,16 @@ class ServerIntrospection
 
         $multicallParams = [];
         foreach ($methods as $method) {
-            $multicallParams[] = ['methodName' => 'system.methodSignature',
-                                       'params'     => [$method]];
+            $multicallParams[] = [
+                'methodName' => 'system.methodSignature',
+                'params'     => [$method],
+            ];
         }
 
         $serverSignatures = $this->system->multicall($multicallParams);
 
         if (! is_array($serverSignatures)) {
-            $type = gettype($serverSignatures);
+            $type  = gettype($serverSignatures);
             $error = "Multicall return is malformed.  Expected array, got $type";
             throw new Exception\IntrospectException($error);
         }

--- a/src/Client/ServerProxy.php
+++ b/src/Client/ServerProxy.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Client;
 
 use Laminas\XmlRpc\Client as XMLRPCClient;

--- a/src/Client/ServerProxy.php
+++ b/src/Client/ServerProxy.php
@@ -10,6 +10,8 @@ namespace Laminas\XmlRpc\Client;
 
 use Laminas\XmlRpc\Client as XMLRPCClient;
 
+use function ltrim;
+
 /**
  * The namespace decorator enables object chaining to permit
  * calling XML-RPC namespaced functions like "foo.bar.baz()"
@@ -17,25 +19,16 @@ use Laminas\XmlRpc\Client as XMLRPCClient;
  */
 class ServerProxy
 {
-    /**
-     * @var \Laminas\XmlRpc\Client
-     */
-    private $client = null;
+    /** @var XMLRPCClient */
+    private $client;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $namespace = '';
 
-    /**
-     * @var array of \Laminas\XmlRpc\Client\ServerProxy
-     */
+    /** @var array of \Laminas\XmlRpc\Client\ServerProxy */
     private $cache = [];
 
     /**
-     * Class constructor
-     *
-     * @param \Laminas\XmlRpc\Client $client
      * @param string             $namespace
      */
     public function __construct(XMLRPCClient $client, $namespace = '')
@@ -48,7 +41,7 @@ class ServerProxy
      * Get the next successive namespace
      *
      * @param string $namespace
-     * @return \Laminas\XmlRpc\Client\ServerProxy
+     * @return ServerProxy
      */
     public function __get($namespace)
     {

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Exception;
 
 class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Exception;
 
 interface ExceptionInterface

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Exception;
 
 class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Exception;
 
 class RuntimeException extends \RuntimeException implements ExceptionInterface

--- a/src/Exception/ValueException.php
+++ b/src/Exception/ValueException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Exception;
 
 use LogicException;

--- a/src/Exception/ValueException.php
+++ b/src/Exception/ValueException.php
@@ -8,6 +8,8 @@
 
 namespace Laminas\XmlRpc\Exception;
 
-class ValueException extends \LogicException implements ExceptionInterface
+use LogicException;
+
+class ValueException extends LogicException implements ExceptionInterface
 {
 }

--- a/src/Fault.php
+++ b/src/Fault.php
@@ -8,8 +8,14 @@
 
 namespace Laminas\XmlRpc;
 
+use Laminas\Xml\Exception\RuntimeException;
 use Laminas\Xml\Security as XmlSecurity;
 use SimpleXMLElement;
+
+use function array_reduce;
+use function is_string;
+use function libxml_get_errors;
+use function libxml_use_internal_errors;
 
 /**
  * XMLRPC Faults
@@ -25,24 +31,28 @@ class Fault
 {
     /**
      * Fault code
+     *
      * @var int
      */
     protected $code;
 
     /**
      * Fault character encoding
+     *
      * @var string
      */
     protected $encoding = 'UTF-8';
 
     /**
      * Fault message
+     *
      * @var string
      */
     protected $message;
 
     /**
      * Internal fault codes => messages
+     *
      * @var array
      */
     protected $internal = [
@@ -183,9 +193,9 @@ class Fault
         $xmlErrorsFlag = libxml_use_internal_errors(true);
         try {
             $xml = XmlSecurity::scan($fault);
-        } catch (\Laminas\Xml\Exception\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             // Unsecure XML
-            throw new Exception\RuntimeException('Failed to parse XML fault: ' .  $e->getMessage(), 500, $e);
+            throw new Exception\RuntimeException('Failed to parse XML fault: ' . $e->getMessage(), 500, $e);
         }
         if (! $xml instanceof SimpleXMLElement) {
             $errors = libxml_get_errors();
@@ -272,9 +282,9 @@ class Fault
         // Create fault value
         $faultStruct = [
             'faultCode'   => $this->getCode(),
-            'faultString' => $this->getMessage()
+            'faultString' => $this->getMessage(),
         ];
-        $value = AbstractValue::getXmlRpcValue($faultStruct);
+        $value       = AbstractValue::getXmlRpcValue($faultStruct);
 
         $generator = AbstractValue::getGenerator();
         $generator->openElement('methodResponse')

--- a/src/Fault.php
+++ b/src/Fault.php
@@ -133,7 +133,7 @@ class Fault
     /**
      * Retrieve fault message
      *
-     * @param string
+     * @param string $message
      * @return Fault
      */
     public function setMessage($message)
@@ -181,8 +181,8 @@ class Fault
      * @param string $fault
      * @return bool Returns true if successfully loaded fault response, false
      * if response was not a fault response
-     * @throws Exception\ExceptionInterface if no or faulty XML provided, or if fault
-     * response does not contain either code or message
+     * @throws Exception\ExceptionInterface If no or faulty XML provided, or if fault
+     * response does not contain either code or message.
      */
     public function loadXml($fault)
     {

--- a/src/Fault.php
+++ b/src/Fault.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc;
 
 use Laminas\Xml\Exception\RuntimeException;

--- a/src/Generator/AbstractGenerator.php
+++ b/src/Generator/AbstractGenerator.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Generator;
 
 use function preg_replace;

--- a/src/Generator/AbstractGenerator.php
+++ b/src/Generator/AbstractGenerator.php
@@ -8,6 +8,8 @@
 
 namespace Laminas\XmlRpc\Generator;
 
+use function preg_replace;
+
 /**
  * Abstract XML generator adapter
  */

--- a/src/Generator/DomDocument.php
+++ b/src/Generator/DomDocument.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Generator;
 
 use DOMNode;

--- a/src/Generator/DomDocument.php
+++ b/src/Generator/DomDocument.php
@@ -15,14 +15,10 @@ use DOMNode;
  */
 class DomDocument extends AbstractGenerator
 {
-    /**
-     * @var \DOMDocument
-     */
+    /** @var \DOMDocument */
     protected $dom;
 
-    /**
-     * @var DOMNode
-     */
+    /** @var DOMNode */
     protected $currentElement;
 
     /**
@@ -80,7 +76,7 @@ class DomDocument extends AbstractGenerator
      */
     protected function init()
     {
-        $this->dom = new \DOMDocument('1.0', $this->encoding);
+        $this->dom            = new \DOMDocument('1.0', $this->encoding);
         $this->currentElement = $this->dom;
     }
 }

--- a/src/Generator/GeneratorInterface.php
+++ b/src/Generator/GeneratorInterface.php
@@ -14,8 +14,11 @@ namespace Laminas\XmlRpc\Generator;
 interface GeneratorInterface
 {
     public function getEncoding();
+
     public function setEncoding($encoding);
+
     public function openElement($name, $value = null);
+
     public function closeElement($name);
 
     /**
@@ -26,6 +29,8 @@ interface GeneratorInterface
     public function saveXml();
 
     public function stripDeclaration($xml);
+
     public function flush();
+
     public function __toString();
 }

--- a/src/Generator/GeneratorInterface.php
+++ b/src/Generator/GeneratorInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Generator;
 
 /**

--- a/src/Generator/GeneratorInterface.php
+++ b/src/Generator/GeneratorInterface.php
@@ -15,10 +15,20 @@ interface GeneratorInterface
 {
     public function getEncoding();
 
+    /**
+     * @param string $encoding
+     */
     public function setEncoding($encoding);
 
+    /**
+     * @param string $name
+     * @param string $value
+     */
     public function openElement($name, $value = null);
 
+    /**
+     * @param string $name
+     */
     public function closeElement($name);
 
     /**
@@ -28,6 +38,10 @@ interface GeneratorInterface
      */
     public function saveXml();
 
+    /**
+     * @param  string $xml
+     * @return string
+     */
     public function stripDeclaration($xml);
 
     public function flush();

--- a/src/Generator/XmlWriter.php
+++ b/src/Generator/XmlWriter.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Generator;
 
 /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc;
 
 use DOMDocument;

--- a/src/Request.php
+++ b/src/Request.php
@@ -11,6 +11,7 @@ namespace Laminas\XmlRpc;
 use DOMDocument;
 use Exception;
 use Laminas\Stdlib\ErrorHandler;
+use Laminas\XmlRpc\Exception\ValueException;
 use Laminas\XmlRpc\Fault;
 use SimpleXMLElement;
 
@@ -292,7 +293,7 @@ class Request
      * Load XML and parse into request components
      *
      * @param string $request
-     * @throws Exception\ValueException If invalid XML.
+     * @throws ValueException If invalid XML.
      * @return bool True on success, false if an error occurred.
      */
     public function loadXml($request)
@@ -313,7 +314,7 @@ class Request
             $dom->loadXML($request);
             foreach ($dom->childNodes as $child) {
                 if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {
-                    throw new Exception\ValueException(
+                    throw new ValueException(
                         'Invalid XML: Detected use of illegal DOCTYPE'
                     );
                 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -208,11 +208,11 @@ class Request
     {
         $argc = func_num_args();
         $argv = func_get_args();
-        if (0 == $argc) {
+        if (0 === $argc) {
             return;
         }
 
-        if ((1 == $argc) && is_array($argv[0])) {
+        if ((1 === $argc) && is_array($argv[0])) {
             $params     = [];
             $types      = [];
             $wellFormed = true;
@@ -292,7 +292,7 @@ class Request
      * Load XML and parse into request components
      *
      * @param string $request
-     * @throws Exception\ValueException if invalid XML
+     * @throws Exception\ValueException If invalid XML.
      * @return bool True on success, false if an error occurred.
      */
     public function loadXml($request)

--- a/src/Request/Http.php
+++ b/src/Request/Http.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Request;
 
 use Laminas\Stdlib\ErrorHandler;

--- a/src/Request/Http.php
+++ b/src/Request/Http.php
@@ -12,6 +12,12 @@ use Laminas\Stdlib\ErrorHandler;
 use Laminas\XmlRpc\Fault;
 use Laminas\XmlRpc\Request as XmlRpcRequest;
 
+use function file_get_contents;
+use function str_replace;
+use function strtolower;
+use function substr;
+use function ucwords;
+
 /**
  * XmlRpc Request object -- Request via HTTP
  *
@@ -23,12 +29,14 @@ class Http extends XmlRpcRequest
 {
     /**
      * Array of headers
+     *
      * @var array
      */
     protected $headers;
 
     /**
      * Raw XML as received via request
+     *
      * @var string
      */
     protected $xml;
@@ -39,7 +47,6 @@ class Http extends XmlRpcRequest
      * Attempts to read from php://input to get raw POST request; if an error
      * occurs in doing so, or if the XML is invalid, the request is declared a
      * fault.
-     *
      */
     public function __construct()
     {
@@ -79,7 +86,7 @@ class Http extends XmlRpcRequest
             $this->headers = [];
             foreach ($_SERVER as $key => $value) {
                 if ('HTTP_' == substr($key, 0, 5)) {
-                    $header = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))));
+                    $header                 = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))));
                     $this->headers[$header] = $value;
                 }
             }

--- a/src/Request/Http.php
+++ b/src/Request/Http.php
@@ -85,8 +85,12 @@ class Http extends XmlRpcRequest
         if (null === $this->headers) {
             $this->headers = [];
             foreach ($_SERVER as $key => $value) {
-                if ('HTTP_' == substr($key, 0, 5)) {
-                    $header                 = str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($key, 5)))));
+                if ('HTTP_' === substr($key, 0, 5)) {
+                    $header                 = str_replace(
+                        ' ',
+                        '-',
+                        ucwords(strtolower(str_replace('_', ' ', substr($key, 5))))
+                    );
                     $this->headers[$header] = $value;
                 }
             }

--- a/src/Request/Stdin.php
+++ b/src/Request/Stdin.php
@@ -11,6 +11,11 @@ namespace Laminas\XmlRpc\Request;
 use Laminas\XmlRpc\Fault;
 use Laminas\XmlRpc\Request as XmlRpcRequest;
 
+use function fclose;
+use function feof;
+use function fgets;
+use function fopen;
+
 /**
  * XmlRpc Request object -- Request via STDIN
  *
@@ -22,6 +27,7 @@ class Stdin extends XmlRpcRequest
 {
     /**
      * Raw XML as received via request
+     *
      * @var string
      */
     protected $xml;
@@ -32,7 +38,6 @@ class Stdin extends XmlRpcRequest
      * Attempts to read from php://stdin to get raw POST request; if an error
      * occurs in doing so, or if the XML is invalid, the request is declared a
      * fault.
-     *
      */
     public function __construct()
     {

--- a/src/Request/Stdin.php
+++ b/src/Request/Stdin.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Request;
 
 use Laminas\XmlRpc\Fault;

--- a/src/Response.php
+++ b/src/Response.php
@@ -8,7 +8,12 @@
 
 namespace Laminas\XmlRpc;
 
+use Laminas\Xml\Exception\RuntimeException;
 use Laminas\Xml\Security as XmlSecurity;
+use Laminas\XmlRpc\AbstractValue;
+use Laminas\XmlRpc\Fault;
+
+use function is_string;
 
 /**
  * XmlRpc Response
@@ -19,27 +24,31 @@ class Response
 {
     /**
      * Return value
+     *
      * @var mixed
      */
     protected $return;
 
     /**
      * Return type
+     *
      * @var string
      */
     protected $type;
 
     /**
      * Response character encoding
+     *
      * @var string
      */
     protected $encoding = 'UTF-8';
 
     /**
      * Fault, if response is a fault response
-     * @var null|\Laminas\XmlRpc\Fault
+     *
+     * @var null|Fault
      */
-    protected $fault = null;
+    protected $fault;
 
     /**
      * Constructor
@@ -59,7 +68,7 @@ class Response
      * Set encoding to use in response
      *
      * @param string $encoding
-     * @return \Laminas\XmlRpc\Response
+     * @return Response
      */
     public function setEncoding($encoding)
     {
@@ -90,7 +99,7 @@ class Response
     public function setReturnValue($value, $type = null)
     {
         $this->return = $value;
-        $this->type = (string) $type;
+        $this->type   = (string) $type;
     }
 
     /**
@@ -106,7 +115,7 @@ class Response
     /**
      * Retrieve the XMLRPC value for the return value
      *
-     * @return \Laminas\XmlRpc\AbstractValue
+     * @return AbstractValue
      */
     protected function getXmlRpcReturn()
     {
@@ -126,7 +135,7 @@ class Response
     /**
      * Returns the fault, if any.
      *
-     * @return null|\Laminas\XmlRpc\Fault
+     * @return null|Fault
      */
     public function getFault()
     {
@@ -154,7 +163,7 @@ class Response
 
         try {
             $xml = XmlSecurity::scan($response);
-        } catch (\Laminas\Xml\Exception\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             $this->fault = new Fault(651);
             $this->fault->setEncoding($this->getEncoding());
             return false;
@@ -180,7 +189,7 @@ class Response
                 throw new Exception\ValueException('Missing XML-RPC value in XML');
             }
             $valueXml = $xml->params->param->value->asXML();
-            $value = AbstractValue::getXmlRpcValue($valueXml, AbstractValue::XML_STRING);
+            $value    = AbstractValue::getXmlRpcValue($valueXml, AbstractValue::XML_STRING);
         } catch (Exception\ValueException $e) {
             $this->fault = new Fault(653);
             $this->fault->setEncoding($this->getEncoding());
@@ -198,7 +207,7 @@ class Response
      */
     public function saveXml()
     {
-        $value = $this->getXmlRpcReturn();
+        $value     = $this->getXmlRpcReturn();
         $generator = AbstractValue::getGenerator();
         $generator->openElement('methodResponse')
                   ->openElement('params')

--- a/src/Response.php
+++ b/src/Response.php
@@ -149,7 +149,7 @@ class Response
      * is a fault response.
      *
      * @param string $response
-     * @throws Exception\ValueException if invalid XML
+     * @throws Exception\ValueException If invalid XML.
      * @return bool True if a valid XMLRPC response, false if a fault
      * response or invalid input
      */

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc;
 
 use Laminas\Xml\Exception\RuntimeException;

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -6,6 +6,7 @@ use Laminas\XmlRpc\Response as XmlRpcResponse;
 
 use function header;
 use function headers_sent;
+use function strtolower;
 
 /**
  * HTTP response
@@ -20,7 +21,7 @@ class Http extends XmlRpcResponse
     public function __toString()
     {
         if (! headers_sent()) {
-            header('Content-Type: text/xml; charset=' . $this->getEncoding());
+            header('Content-Type: text/xml; charset=' . strtolower($this->getEncoding()));
         }
 
         return parent::__toString();

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -12,7 +12,6 @@ use Laminas\XmlRpc\Response as XmlRpcResponse;
 
 use function header;
 use function headers_sent;
-use function strtolower;
 
 /**
  * HTTP response
@@ -27,7 +26,7 @@ class Http extends XmlRpcResponse
     public function __toString()
     {
         if (! headers_sent()) {
-            header('Content-Type: text/xml; charset=' . strtolower($this->getEncoding()));
+            header('Content-Type: text/xml; charset=' . $this->getEncoding());
         }
 
         return parent::__toString();

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -10,6 +10,10 @@ namespace Laminas\XmlRpc\Response;
 
 use Laminas\XmlRpc\Response as XmlRpcResponse;
 
+use function header;
+use function headers_sent;
+use function strtolower;
+
 /**
  * HTTP response
  */

--- a/src/Response/Http.php
+++ b/src/Response/Http.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Response;
 
 use Laminas\XmlRpc\Response as XmlRpcResponse;

--- a/src/Server.php
+++ b/src/Server.php
@@ -14,6 +14,7 @@ use Laminas\Server\Definition;
 use Laminas\Server\Reflection;
 use Laminas\XmlRpc\Response;
 use Laminas\XmlRpc\Response\Http;
+use Laminas\XmlRpc\Server\Exception\InvalidArgumentException;
 
 use function array_merge;
 use function array_slice;
@@ -190,13 +191,13 @@ class Server extends AbstractServer
      *
      * @param string|array|callable $function  Valid callback
      * @param string                $namespace Optional namespace prefix
-     * @throws Server\Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return void
      */
     public function addFunction($function, $namespace = '')
     {
         if (! is_string($function) && ! is_array($function)) {
-            throw new Server\Exception\InvalidArgumentException('Unable to attach function; invalid', 611);
+            throw new InvalidArgumentException('Unable to attach function; invalid', 611);
         }
 
         $argv = null;
@@ -208,7 +209,7 @@ class Server extends AbstractServer
         $function = (array) $function;
         foreach ($function as $func) {
             if (! is_string($func) || ! function_exists($func)) {
-                throw new Server\Exception\InvalidArgumentException('Unable to attach function; invalid', 611);
+                throw new InvalidArgumentException('Unable to attach function; invalid', 611);
             }
             $reflection = Reflection::reflectFunction($func, $argv, $namespace);
             $this->_buildSignature($reflection);
@@ -230,12 +231,12 @@ class Server extends AbstractServer
      * @param string $namespace Optional
      * @param mixed $argv Optional arguments to pass to methods
      * @return void
-     * @throws Server\Exception\InvalidArgumentException on invalid input
+     * @throws InvalidArgumentException On invalid input.
      */
     public function setClass($class, $namespace = '', $argv = null)
     {
         if (is_string($class) && ! class_exists($class)) {
-            throw new Server\Exception\InvalidArgumentException('Invalid method class', 610);
+            throw new InvalidArgumentException('Invalid method class', 610);
         }
 
         if (2 < func_num_args()) {
@@ -345,7 +346,7 @@ class Server extends AbstractServer
      *
      * @param  array|Definition $definition
      * @return void
-     * @throws Server\Exception\InvalidArgumentException on invalid input
+     * @throws InvalidArgumentException On invalid input.
      */
     public function loadFunctions($definition)
     {
@@ -355,7 +356,7 @@ class Server extends AbstractServer
             } else {
                 $type = gettype($definition);
             }
-            throw new Server\Exception\InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Unable to load server definition; must be an array or Laminas\Server\Definition, received ' . $type,
                 612
             );
@@ -369,7 +370,7 @@ class Server extends AbstractServer
         }
 
         foreach ($definition as $key => $method) {
-            if ('system.' == substr($key, 0, 7)) {
+            if ('system.' === substr($key, 0, 7)) {
                 continue;
             }
             $this->table->addMethod($method, $key);
@@ -414,18 +415,18 @@ class Server extends AbstractServer
      *
      * @param  string|Request $request
      * @return Server
-     * @throws Server\Exception\InvalidArgumentException on invalid request class or object
+     * @throws InvalidArgumentException On invalid request class or object.
      */
     public function setRequest($request)
     {
         if (is_string($request) && class_exists($request)) {
             $request = new $request();
             if (! $request instanceof Request) {
-                throw new Server\Exception\InvalidArgumentException('Invalid request class');
+                throw new InvalidArgumentException('Invalid request class');
             }
             $request->setEncoding($this->getEncoding());
         } elseif (! $request instanceof Request) {
-            throw new Server\Exception\InvalidArgumentException('Invalid request object');
+            throw new InvalidArgumentException('Invalid request object');
         }
 
         $this->request = $request;
@@ -456,13 +457,13 @@ class Server extends AbstractServer
      * Set the class to use for the response
      *
      * @param  string $class
-     * @throws Server\Exception\InvalidArgumentException if invalid response class
+     * @throws InvalidArgumentException If invalid response class.
      * @return bool True if class was set, false if not
      */
     public function setResponseClass($class)
     {
         if (! class_exists($class) || ! is_subclass_of($class, Response::class)) {
-            throw new Server\Exception\InvalidArgumentException('Invalid response class');
+            throw new InvalidArgumentException('Invalid response class');
         }
         $this->responseClass = $class;
         return true;
@@ -568,7 +569,7 @@ class Server extends AbstractServer
         $info   = $this->table->getMethod($method);
         $params = $request->getParams();
         $argv   = $info->getInvokeArguments();
-        if (0 < count($argv) and $this->sendArgumentsToAllMethods()) {
+        if (0 < count($argv) && $this->sendArgumentsToAllMethods()) {
             $params = array_merge($params, $argv);
         }
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc;
 
 use Exception;

--- a/src/Server/Cache.php
+++ b/src/Server/Cache.php
@@ -13,9 +13,7 @@ namespace Laminas\XmlRpc\Server;
  */
 class Cache extends \Laminas\Server\Cache
 {
-    /**
-     * @var array Skip system methods when caching XML-RPC server
-     */
+    /** @var array Skip system methods when caching XML-RPC server */
     protected static $skipMethods = [
         'system.listMethods',
         'system.methodHelp',

--- a/src/Server/Cache.php
+++ b/src/Server/Cache.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Server;
 
 /**

--- a/src/Server/Exception/BadMethodCallException.php
+++ b/src/Server/Exception/BadMethodCallException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Server\Exception;
 
 use Laminas\XmlRpc\Exception;

--- a/src/Server/Exception/ExceptionInterface.php
+++ b/src/Server/Exception/ExceptionInterface.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Server\Exception;
 
 use Laminas\XmlRpc\Exception\ExceptionInterface as Exception;

--- a/src/Server/Exception/InvalidArgumentException.php
+++ b/src/Server/Exception/InvalidArgumentException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Server\Exception;
 
 use Laminas\XmlRpc\Exception;

--- a/src/Server/Exception/RuntimeException.php
+++ b/src/Server/Exception/RuntimeException.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Server\Exception;
 
 use Laminas\XmlRpc\Exception;

--- a/src/Server/Fault.php
+++ b/src/Server/Fault.php
@@ -43,11 +43,6 @@ class Fault extends \Laminas\XmlRpc\Fault
     /** @var array Array of fault observers */
     protected static $observers = [];
 
-    /**
-     * Constructor
-     *
-     * @return Fault
-     */
     public function __construct(Exception $e)
     {
         $this->exception = $e;

--- a/src/Server/Fault.php
+++ b/src/Server/Fault.php
@@ -8,6 +8,15 @@
 
 namespace Laminas\XmlRpc\Server;
 
+use Exception;
+use Laminas\XmlRpc\Server\Exception\ExceptionInterface;
+
+use function array_keys;
+use function class_exists;
+use function is_array;
+use function is_callable;
+use function is_string;
+
 /**
  * XMLRPC Server Faults
  *
@@ -25,32 +34,25 @@ namespace Laminas\XmlRpc\Server;
  */
 class Fault extends \Laminas\XmlRpc\Fault
 {
-    /**
-     * @var \Exception
-     */
+    /** @var Exception */
     protected $exception;
 
-    /**
-     * @var array Array of exception classes that may define xmlrpc faults
-     */
-    protected static $faultExceptionClasses = ['Laminas\\XmlRpc\\Server\\Exception\\ExceptionInterface' => true];
+    /** @var array Array of exception classes that may define xmlrpc faults */
+    protected static $faultExceptionClasses = [ExceptionInterface::class => true];
 
-    /**
-     * @var array Array of fault observers
-     */
+    /** @var array Array of fault observers */
     protected static $observers = [];
 
     /**
      * Constructor
      *
-     * @param  \Exception $e
      * @return Fault
      */
-    public function __construct(\Exception $e)
+    public function __construct(Exception $e)
     {
         $this->exception = $e;
-        $code             = 404;
-        $message          = 'Unknown error';
+        $code            = 404;
+        $message         = 'Unknown error';
 
         foreach (array_keys(static::$faultExceptionClasses) as $class) {
             if ($e instanceof $class) {
@@ -73,10 +75,9 @@ class Fault extends \Laminas\XmlRpc\Fault
     /**
      * Return Laminas\XmlRpc\Server\Fault instance
      *
-     * @param \Exception $e
      * @return Fault
      */
-    public static function getInstance(\Exception $e)
+    public static function getInstance(Exception $e)
     {
         return new static($e);
     }
@@ -164,7 +165,7 @@ class Fault extends \Laminas\XmlRpc\Fault
      * Retrieve the exception
      *
      * @access public
-     * @return \Exception
+     * @return Exception
      */
     public function getException()
     {

--- a/src/Server/Fault.php
+++ b/src/Server/Fault.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Server;
 
 use Exception;

--- a/src/Server/System.php
+++ b/src/Server/System.php
@@ -12,6 +12,7 @@ use Exception;
 use Laminas\XmlRpc\Fault;
 use Laminas\XmlRpc\Request;
 use Laminas\XmlRpc\Server;
+use Laminas\XmlRpc\Server\Exception\InvalidArgumentException;
 
 use function array_keys;
 use function is_array;
@@ -50,14 +51,14 @@ class System
      * Display help message for an XMLRPC method
      *
      * @param string $method
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return string
      */
     public function methodHelp($method)
     {
         $table = $this->server->getDispatchTable();
         if (! $table->hasMethod($method)) {
-            throw new Exception\InvalidArgumentException('Method "' . $method . '" does not exist', 640);
+            throw new InvalidArgumentException('Method "' . $method . '" does not exist', 640);
         }
 
         return $table->getMethod($method)->getMethodHelp();
@@ -67,14 +68,14 @@ class System
      * Return a method signature
      *
      * @param string $method
-     * @throws Exception\InvalidArgumentException
+     * @throws InvalidArgumentException
      * @return array
      */
     public function methodSignature($method)
     {
         $table = $this->server->getDispatchTable();
         if (! $table->hasMethod($method)) {
-            throw new Exception\InvalidArgumentException('Method "' . $method . '" does not exist', 640);
+            throw new InvalidArgumentException('Method "' . $method . '" does not exist', 640);
         }
         $method = $table->getMethod($method)->toArray();
         return $method['prototypes'];

--- a/src/Server/System.php
+++ b/src/Server/System.php
@@ -8,22 +8,27 @@
 
 namespace Laminas\XmlRpc\Server;
 
+use Exception;
+use Laminas\XmlRpc\Fault;
+use Laminas\XmlRpc\Request;
+use Laminas\XmlRpc\Server;
+
+use function array_keys;
+use function is_array;
+use function var_export;
+
 /**
  * XML-RPC system.* methods
  */
 class System
 {
-    /**
-     * @var \Laminas\XmlRpc\Server
-     */
+    /** @var Server */
     protected $server;
 
     /**
      * Constructor
-     *
-     * @param \Laminas\XmlRpc\Server $server
      */
-    public function __construct(\Laminas\XmlRpc\Server $server)
+    public function __construct(Server $server)
     {
         $this->server = $server;
     }
@@ -89,6 +94,7 @@ class System
      * struct with a fault response.
      *
      * @see http://www.xmlrpc.com/discuss/msgReader$1208
+     *
      * @param  array $methods
      * @return array
      */
@@ -114,18 +120,19 @@ class System
 
             if (! $fault) {
                 try {
-                    $request = new \Laminas\XmlRpc\Request();
+                    $request = new Request();
                     $request->setMethod($method['methodName']);
                     $request->setParams($method['params']);
                     $response = $this->server->handle($request);
-                    if ($response instanceof \Laminas\XmlRpc\Fault
+                    if (
+                        $response instanceof Fault
                         || $response->isFault()
                     ) {
                         $fault = $response;
                     } else {
                         $responses[] = $response->getReturnValue();
                     }
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     $fault = $this->server->fault($e);
                 }
             }
@@ -133,7 +140,7 @@ class System
             if ($fault) {
                 $responses[] = [
                     'faultCode'   => $fault->getCode(),
-                    'faultString' => $fault->getMessage()
+                    'faultString' => $fault->getMessage(),
                 ];
             }
         }

--- a/src/Server/System.php
+++ b/src/Server/System.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Server;
 
 use Exception;

--- a/src/Server/System.php
+++ b/src/Server/System.php
@@ -112,7 +112,7 @@ class System
             } elseif (! is_array($method['params'])) {
                 $fault = $this->server->fault('Params must be an array', 604);
             } else {
-                if ('system.multicall' == $method['methodName']) {
+                if ('system.multicall' === $method['methodName']) {
                     // don't allow recursive calls to multicall
                     $fault = $this->server->fault('Recursive system.multicall forbidden', 605);
                 }

--- a/src/Value/AbstractCollection.php
+++ b/src/Value/AbstractCollection.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 use Laminas\XmlRpc\AbstractValue;

--- a/src/Value/AbstractScalar.php
+++ b/src/Value/AbstractScalar.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 use Laminas\XmlRpc\AbstractValue;

--- a/src/Value/ArrayValue.php
+++ b/src/Value/ArrayValue.php
@@ -8,6 +8,8 @@
 
 namespace Laminas\XmlRpc\Value;
 
+use function is_array;
+
 class ArrayValue extends AbstractCollection
 {
     /**

--- a/src/Value/ArrayValue.php
+++ b/src/Value/ArrayValue.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 use function is_array;

--- a/src/Value/Base64.php
+++ b/src/Value/Base64.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 use function base64_decode;

--- a/src/Value/Base64.php
+++ b/src/Value/Base64.php
@@ -8,6 +8,9 @@
 
 namespace Laminas\XmlRpc\Value;
 
+use function base64_decode;
+use function base64_encode;
+
 class Base64 extends AbstractScalar
 {
     /**

--- a/src/Value/BigInteger.php
+++ b/src/Value/BigInteger.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 use Laminas\Math\BigInteger\BigInteger as BigIntegerMath;

--- a/src/Value/Boolean.php
+++ b/src/Value/Boolean.php
@@ -21,7 +21,7 @@ class Boolean extends AbstractScalar
         $this->type = self::XMLRPC_TYPE_BOOLEAN;
         // Make sure the value is boolean and then convert it into an integer
         // The double conversion is because a bug in the LaminasOptimizer in PHP version 5.0.4
-        $this->value = (int)(bool) $value;
+        $this->value = (int) (bool) $value;
     }
 
     /**

--- a/src/Value/Boolean.php
+++ b/src/Value/Boolean.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 class Boolean extends AbstractScalar

--- a/src/Value/DateTime.php
+++ b/src/Value/DateTime.php
@@ -10,6 +10,9 @@ namespace Laminas\XmlRpc\Value;
 
 use Laminas\XmlRpc\Exception;
 
+use function date;
+use function is_numeric;
+
 class DateTime extends AbstractScalar
 {
     /**

--- a/src/Value/DateTime.php
+++ b/src/Value/DateTime.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 use Laminas\XmlRpc\Exception;

--- a/src/Value/DateTime.php
+++ b/src/Value/DateTime.php
@@ -36,7 +36,7 @@ class DateTime extends AbstractScalar
      *
      * @param mixed $value Integer of the unix timestamp or any string that can be parsed
      *                     to a unix timestamp using the PHP strtotime() function
-     * @throws Exception\ValueException if unable to create a DateTime object from $value
+     * @throws Exception\ValueException If unable to create a DateTime object from $value.
      */
     public function __construct($value)
     {

--- a/src/Value/Double.php
+++ b/src/Value/Double.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 use function ini_get;

--- a/src/Value/Double.php
+++ b/src/Value/Double.php
@@ -8,6 +8,10 @@
 
 namespace Laminas\XmlRpc\Value;
 
+use function ini_get;
+use function rtrim;
+use function sprintf;
+
 class Double extends AbstractScalar
 {
     /**
@@ -17,10 +21,10 @@ class Double extends AbstractScalar
      */
     public function __construct($value)
     {
-        $this->type = self::XMLRPC_TYPE_DOUBLE;
-        $precision = (int) ini_get('precision');
+        $this->type   = self::XMLRPC_TYPE_DOUBLE;
+        $precision    = (int) ini_get('precision');
         $formatString = '%1.' . $precision . 'F';
-        $this->value = rtrim(sprintf($formatString, (float) $value), '0');
+        $this->value  = rtrim(sprintf($formatString, (float) $value), '0');
     }
 
     /**

--- a/src/Value/Integer.php
+++ b/src/Value/Integer.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 use Laminas\XmlRpc\Exception;

--- a/src/Value/Integer.php
+++ b/src/Value/Integer.php
@@ -10,6 +10,8 @@ namespace Laminas\XmlRpc\Value;
 
 use Laminas\XmlRpc\Exception;
 
+use const PHP_INT_MAX;
+
 class Integer extends AbstractScalar
 {
     /**
@@ -24,7 +26,7 @@ class Integer extends AbstractScalar
             throw new Exception\ValueException('Overlong integer given');
         }
 
-        $this->type = self::XMLRPC_TYPE_INTEGER;
+        $this->type  = self::XMLRPC_TYPE_INTEGER;
         $this->value = (int) $value;    // Make sure this value is integer
     }
 

--- a/src/Value/Nil.php
+++ b/src/Value/Nil.php
@@ -12,11 +12,10 @@ class Nil extends AbstractScalar
 {
     /**
      * Set the value of a nil native type
-     *
      */
     public function __construct()
     {
-        $this->type = self::XMLRPC_TYPE_NIL;
+        $this->type  = self::XMLRPC_TYPE_NIL;
         $this->value = null;
     }
 

--- a/src/Value/Nil.php
+++ b/src/Value/Nil.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 class Nil extends AbstractScalar

--- a/src/Value/Nil.php
+++ b/src/Value/Nil.php
@@ -21,11 +21,8 @@ class Nil extends AbstractScalar
 
     /**
      * Return the value of this object, convert the XML-RPC native nill value into a PHP NULL
-     *
-     * @return null
      */
-    public function getValue()
+    public function getValue(): void
     {
-        return;
     }
 }

--- a/src/Value/Struct.php
+++ b/src/Value/Struct.php
@@ -8,6 +8,8 @@
 
 namespace Laminas\XmlRpc\Value;
 
+use function is_array;
+
 class Struct extends AbstractCollection
 {
     /**

--- a/src/Value/Struct.php
+++ b/src/Value/Struct.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 use function is_array;

--- a/src/Value/Text.php
+++ b/src/Value/Text.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace Laminas\XmlRpc\Value;
 
 class Text extends AbstractScalar

--- a/test/AbstractTestProvider.php
+++ b/test/AbstractTestProvider.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 use Laminas\XmlRpc\Generator;

--- a/test/AbstractTestProvider.php
+++ b/test/AbstractTestProvider.php
@@ -10,9 +10,9 @@ namespace LaminasTest\XmlRpc;
 
 use Laminas\XmlRpc\Generator;
 
-abstract class TestProvider
+abstract class AbstractTestProvider
 {
-    public static function provideGenerators()
+    public static function provideGenerators(): array
     {
         return [
             [new Generator\DomDocument()],
@@ -20,7 +20,7 @@ abstract class TestProvider
         ];
     }
 
-    public static function provideGeneratorsWithAlternateEncodings()
+    public static function provideGeneratorsWithAlternateEncodings(): array
     {
         return [
             [new Generator\DomDocument('ISO-8859-1')],

--- a/test/BigIntegerValueTest.php
+++ b/test/BigIntegerValueTest.php
@@ -35,7 +35,7 @@ class BigIntegerValueTest extends TestCase
             $this->markTestSkipped('gmp causes test failure');
         }
         try {
-            $XmlRpcBigInteger = new BigInteger(0);
+            new BigInteger(0);
         } catch (Exception $e) {
             $this->markTestSkipped($e->getMessage());
         }
@@ -86,7 +86,7 @@ class BigIntegerValueTest extends TestCase
 
     /**
      * @group Laminas-6445
-     * @dataProvider \LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarschalBigIntegerFromXmlRpc(Generator $generator)
     {
@@ -108,7 +108,7 @@ class BigIntegerValueTest extends TestCase
 
     /**
      * @group Laminas-6445
-     * @dataProvider \LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarschalBigIntegerFromApacheXmlRpc(Generator $generator)
     {
@@ -146,8 +146,10 @@ class BigIntegerValueTest extends TestCase
         $this->assertSame($bigIntegerValue, $value->getValue());
     }
 
-    // Custom Assertions and Helper Methods
-
+    /**
+     * @param string $xml
+     * @return string
+     */
     public function wrapXml($xml)
     {
         return $xml . "\n";

--- a/test/BigIntegerValueTest.php
+++ b/test/BigIntegerValueTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 use Laminas\Math\Exception;

--- a/test/BigIntegerValueTest.php
+++ b/test/BigIntegerValueTest.php
@@ -8,11 +8,15 @@
 
 namespace LaminasTest\XmlRpc;
 
+use Laminas\Math\Exception;
 use Laminas\XmlRpc\AbstractValue;
 use Laminas\XmlRpc\Generator\GeneratorInterface as Generator;
 use Laminas\XmlRpc\Value\BigInteger;
-use Laminas\XmlRpc\Value\Integer;
 use PHPUnit\Framework\TestCase;
+
+use function extension_loaded;
+
+use const PHP_INT_MAX;
 
 /**
  * @group      Laminas_XmlRpc
@@ -24,7 +28,7 @@ class BigIntegerValueTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->useBigIntForI8Flag = AbstractValue::$USE_BIGINT_FOR_I8;
+        $this->useBigIntForI8Flag         = AbstractValue::$USE_BIGINT_FOR_I8;
         AbstractValue::$USE_BIGINT_FOR_I8 = true;
 
         if (extension_loaded('gmp')) {
@@ -32,7 +36,7 @@ class BigIntegerValueTest extends TestCase
         }
         try {
             $XmlRpcBigInteger = new BigInteger(0);
-        } catch (\Laminas\Math\Exception $e) {
+        } catch (Exception $e) {
             $this->markTestSkipped($e->getMessage());
         }
     }
@@ -40,7 +44,7 @@ class BigIntegerValueTest extends TestCase
     protected function tearDown(): void
     {
         AbstractValue::$USE_BIGINT_FOR_I8 = $this->useBigIntForI8Flag;
-        $this->useBigIntForI8Flag = null;
+        $this->useBigIntForI8Flag         = null;
     }
 
     // BigInteger
@@ -51,8 +55,8 @@ class BigIntegerValueTest extends TestCase
      */
     public function testBigIntegerGetValue()
     {
-        $bigIntegerValue = (string)(PHP_INT_MAX + 42);
-        $bigInteger = new BigInteger($bigIntegerValue);
+        $bigIntegerValue = (string) (PHP_INT_MAX + 42);
+        $bigInteger      = new BigInteger($bigIntegerValue);
         $this->assertSame($bigIntegerValue, $bigInteger->getValue());
     }
 
@@ -61,8 +65,8 @@ class BigIntegerValueTest extends TestCase
      */
     public function testBigIntegerGetType()
     {
-        $bigIntegerValue = (string)(PHP_INT_MAX + 42);
-        $bigInteger = new BigInteger($bigIntegerValue);
+        $bigIntegerValue = (string) (PHP_INT_MAX + 42);
+        $bigInteger      = new BigInteger($bigIntegerValue);
         $this->assertSame(AbstractValue::XMLRPC_TYPE_I8, $bigInteger->getType());
     }
 
@@ -71,8 +75,8 @@ class BigIntegerValueTest extends TestCase
      */
     public function testBigIntegerGeneratedXml()
     {
-        $bigIntegerValue = (string)(PHP_INT_MAX + 42);
-        $bigInteger = new BigInteger($bigIntegerValue);
+        $bigIntegerValue = (string) (PHP_INT_MAX + 42);
+        $bigInteger      = new BigInteger($bigIntegerValue);
 
         $this->assertEquals(
             '<value><i8>' . $bigIntegerValue . '</i8></value>',
@@ -88,9 +92,9 @@ class BigIntegerValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
 
-        $bigIntegerValue = (string)(PHP_INT_MAX + 42);
-        $bigInteger = new BigInteger($bigIntegerValue);
-        $bigIntegerXml = '<value><i8>' . $bigIntegerValue . '</i8></value>';
+        $bigIntegerValue = (string) (PHP_INT_MAX + 42);
+        $bigInteger      = new BigInteger($bigIntegerValue);
+        $bigIntegerXml   = '<value><i8>' . $bigIntegerValue . '</i8></value>';
 
         $value = AbstractValue::getXmlRpcValue(
             $bigIntegerXml,
@@ -110,9 +114,9 @@ class BigIntegerValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
 
-        $bigIntegerValue = (string)(PHP_INT_MAX + 42);
-        $bigInteger = new BigInteger($bigIntegerValue);
-        $bigIntegerXml = '<value><ex:i8 xmlns:ex="http://ws.apache.org/xmlrpc/namespaces/extensions">'
+        $bigIntegerValue = (string) (PHP_INT_MAX + 42);
+        $bigInteger      = new BigInteger($bigIntegerValue);
+        $bigIntegerXml   = '<value><ex:i8 xmlns:ex="http://ws.apache.org/xmlrpc/namespaces/extensions">'
             . $bigIntegerValue
             . '</ex:i8></value>';
 
@@ -131,7 +135,7 @@ class BigIntegerValueTest extends TestCase
      */
     public function testMarshalBigIntegerFromNative()
     {
-        $bigIntegerValue = (string)(PHP_INT_MAX + 42);
+        $bigIntegerValue = (string) (PHP_INT_MAX + 42);
 
         $value = AbstractValue::getXmlRpcValue(
             $bigIntegerValue,
@@ -156,7 +160,7 @@ class BigIntegerValueTest extends TestCase
         }
 
         AbstractValue::$USE_BIGINT_FOR_I8 = $this->useBigIntForI8Flag;
-        $integerValue = PHP_INT_MAX;
+        $integerValue                     = PHP_INT_MAX;
 
         $value = AbstractValue::getXmlRpcValue(
             $integerValue,

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -8,40 +8,45 @@
 
 namespace LaminasTest\XmlRpc;
 
-use Laminas\Http\Client\Adapter;
 use Laminas\Http\Client as HttpClient;
+use Laminas\Http\Client\Adapter;
+use Laminas\Http\Client\Adapter\AdapterInterface;
 use Laminas\Http\Response as HttpResponse;
 use Laminas\XmlRpc\AbstractValue;
 use Laminas\XmlRpc\Client;
+use Laminas\XmlRpc\Client\ServerIntrospection;
+use Laminas\XmlRpc\Client\ServerProxy;
 use Laminas\XmlRpc\Fault;
+use Laminas\XmlRpc\Request;
 use Laminas\XmlRpc\Response;
 use Laminas\XmlRpc\Value;
 use PHPUnit\Framework\TestCase;
+
+use function count;
+use function dirname;
+use function file_get_contents;
+use function implode;
+use function strlen;
+use function time;
 
 /**
  * @group      Laminas_XmlRpc
  */
 class ClientTest extends TestCase
 {
-    /**
-     * @var \Laminas\Http\Client\Adapter\AdapterInterface
-     */
+    /** @var AdapterInterface */
     protected $httpAdapter;
 
-    /**
-     * @var \Laminas\Http\Client
-     */
+    /** @var HttpClient */
     protected $httpClient;
 
-    /**
-     * @var \Laminas\XmlRpc\Client
-     */
+    /** @var Client */
     protected $xmlrpcClient;
 
     protected function setUp(): void
     {
         $this->httpAdapter = new Adapter\Test();
-        $this->httpClient = new HttpClient(
+        $this->httpClient  = new HttpClient(
             'http://foo',
             ['adapter' => $this->httpAdapter]
         );
@@ -55,15 +60,15 @@ class ClientTest extends TestCase
     public function testGettingDefaultHttpClient()
     {
         $xmlrpcClient = new Client('http://foo');
-        $httpClient = $xmlrpcClient->getHttpClient();
-        $this->assertInstanceOf('Laminas\\Http\\Client', $httpClient);
+        $httpClient   = $xmlrpcClient->getHttpClient();
+        $this->assertInstanceOf(HttpClient::class, $httpClient);
         $this->assertSame($httpClient, $xmlrpcClient->getHttpClient());
     }
 
     public function testSettingAndGettingHttpClient()
     {
         $xmlrpcClient = new Client('http://foo');
-        $httpClient = new HttpClient('http://foo');
+        $httpClient   = new HttpClient('http://foo');
         $this->assertNotSame($httpClient, $xmlrpcClient->getHttpClient());
 
         $xmlrpcClient->setHttpClient($httpClient);
@@ -90,8 +95,8 @@ class ClientTest extends TestCase
         $this->setServerResponseTo(true);
         $this->xmlrpcClient->call('foo');
 
-        $this->assertInstanceOf('Laminas\\XmlRpc\\Request', $this->xmlrpcClient->getLastRequest());
-        $this->assertInstanceOf('Laminas\\XmlRpc\\Response', $this->xmlrpcClient->getLastResponse());
+        $this->assertInstanceOf(Request::class, $this->xmlrpcClient->getLastRequest());
+        $this->assertInstanceOf(Response::class, $this->xmlrpcClient->getLastResponse());
     }
 
     public function testSuccessfulRpcMethodCallWithNoParameters()
@@ -151,7 +156,7 @@ class ClientTest extends TestCase
         $actualReturn = $this->xmlrpcClient->call($expectedMethod, $expectedParams);
         $this->assertSame($expectedReturn, $actualReturn);
 
-        $request  = $this->xmlrpcClient->getLastRequest();
+        $request = $this->xmlrpcClient->getLastRequest();
 
         $params = $request->getParams();
         $this->assertSame(count($expectedParams), count($params));
@@ -163,11 +168,11 @@ class ClientTest extends TestCase
      */
     public function testSuccessfulRpcMethodCallWithMixedDateParameters()
     {
-        $time = time();
+        $time           = time();
         $expectedMethod = 'foo.bar';
         $expectedParams = [
             'username',
-            new Value\DateTime($time)
+            new Value\DateTime($time),
         ];
         $expectedReturn = ['username', $time];
 
@@ -197,7 +202,7 @@ class ClientTest extends TestCase
         $params = [
             new Value\Boolean(true),
             new Value\Integer(4),
-            new Value\Text('foo')
+            new Value\Text('foo'),
         ];
         $expect = [true, 4, 'foo'];
 
@@ -307,11 +312,11 @@ class ClientTest extends TestCase
 
     public function testRpcMethodCallThrowsOnXmlRpcFault()
     {
-        $code = 9;
+        $code    = 9;
         $message = 'foo';
 
         $fault = new Fault($code, $message);
-        $xml = $fault->saveXml();
+        $xml   = $fault->saveXml();
 
         $response = $this->makeHttpResponseFrom($xml);
         $this->httpAdapter->setResponse($response);
@@ -326,7 +331,7 @@ class ClientTest extends TestCase
 
     public function testGetProxyReturnsServerProxy()
     {
-        $this->assertInstanceOf('Laminas\\XmlRpc\\Client\\ServerProxy', $this->xmlrpcClient->getProxy());
+        $this->assertInstanceOf(ServerProxy::class, $this->xmlrpcClient->getProxy());
     }
 
     public function testRpcMethodCallsThroughServerProxy()
@@ -379,7 +384,7 @@ class ClientTest extends TestCase
     {
         $xmlrpcClient = new Client('http://foo');
         $introspector = $xmlrpcClient->getIntrospector();
-        $this->assertInstanceOf('Laminas\\XmlRpc\\Client\\ServerIntrospection', $introspector);
+        $this->assertInstanceOf(ServerIntrospection::class, $introspector);
         $this->assertSame($introspector, $xmlrpcClient->getIntrospector());
     }
 
@@ -395,7 +400,7 @@ class ClientTest extends TestCase
 
     public function testGettingMethodSignature()
     {
-        $method = 'foo';
+        $method     = 'foo';
         $signatures = [['int', 'int', 'int']];
         $this->setServerResponseTo($signatures);
 
@@ -423,22 +428,24 @@ class ClientTest extends TestCase
     public function testGettingAllMethodSignaturesByLooping()
     {
         // system.listMethods() will return ['foo', 'bar']
-        $methods = ['foo', 'bar'];
+        $methods  = ['foo', 'bar'];
         $response = $this->getServerResponseFor($methods);
         $this->httpAdapter->setResponse($response);
 
         // system.methodSignature('foo') will return [['int'], ['int', 'string']]
         $fooSignatures = [['int'], ['int', 'string']];
-        $response = $this->getServerResponseFor($fooSignatures);
+        $response      = $this->getServerResponseFor($fooSignatures);
         $this->httpAdapter->addResponse($response);
 
         // system.methodSignature('bar') will return [['boolean']]
         $barSignatures = [['boolean']];
-        $response = $this->getServerResponseFor($barSignatures);
+        $response      = $this->getServerResponseFor($barSignatures);
         $this->httpAdapter->addResponse($response);
 
-        $expected = ['foo' => $fooSignatures,
-                          'bar' => $barSignatures];
+        $expected = [
+            'foo' => $fooSignatures,
+            'bar' => $barSignatures,
+        ];
 
         $i = $this->xmlrpcClient->getIntrospector();
         $this->assertEquals($expected, $i->getSignatureForEachMethodByLooping());
@@ -452,26 +459,34 @@ class ClientTest extends TestCase
     {
         // system.listMethods() will return ['foo', 'bar']
         $whatListMethodsReturns = ['foo', 'bar'];
-        $response = $this->getServerResponseFor($whatListMethodsReturns);
+        $response               = $this->getServerResponseFor($whatListMethodsReturns);
         $this->httpAdapter->setResponse($response);
 
         // after system.listMethods(), these system.multicall() params are expected
-        $multicallParams = [['methodName' => 'system.methodSignature',
-                                       'params'     => ['foo']],
-                                 ['methodName' => 'system.methodSignature',
-                                       'params'     => ['bar']]];
+        $multicallParams = [
+            [
+                'methodName' => 'system.methodSignature',
+                'params'     => ['foo'],
+            ],
+            [
+                'methodName' => 'system.methodSignature',
+                'params'     => ['bar'],
+            ],
+        ];
 
         // system.multicall() will then return [fooSignatures, barSignatures]
-        $fooSignatures = [['int'], ['int', 'string']];
-        $barSignatures = [['boolean']];
+        $fooSignatures        = [['int'], ['int', 'string']];
+        $barSignatures        = [['boolean']];
         $whatMulticallReturns = [$fooSignatures, $barSignatures];
-        $response = $this->getServerResponseFor($whatMulticallReturns);
+        $response             = $this->getServerResponseFor($whatMulticallReturns);
         $this->httpAdapter->addResponse($response);
 
         $i = $this->xmlrpcClient->getIntrospector();
 
-        $expected = ['foo' => $fooSignatures,
-                          'bar' => $barSignatures];
+        $expected = [
+            'foo' => $fooSignatures,
+            'bar' => $barSignatures,
+        ];
         $this->assertEquals($expected, $i->getSignatureForEachMethodByMulticall());
 
         $request = $this->xmlrpcClient->getLastRequest();
@@ -483,11 +498,11 @@ class ClientTest extends TestCase
     {
         // system.listMethods() will return ['foo', 'bar']
         $whatListMethodsReturns = ['foo', 'bar'];
-        $response = $this->getServerResponseFor($whatListMethodsReturns);
+        $response               = $this->getServerResponseFor($whatListMethodsReturns);
         $this->httpAdapter->setResponse($response);
 
         // system.multicall() will then return only [fooSignatures]
-        $fooSignatures = [['int'], ['int', 'string']];
+        $fooSignatures        = [['int'], ['int', 'string']];
         $whatMulticallReturns = [$fooSignatures];  // error! no bar signatures!
 
         $response = $this->getServerResponseFor($whatMulticallReturns);
@@ -504,7 +519,7 @@ class ClientTest extends TestCase
     {
         // system.listMethods() will return ['foo', 'bar']
         $whatListMethodsReturns = ['foo', 'bar'];
-        $response = $this->getServerResponseFor($whatListMethodsReturns);
+        $response               = $this->getServerResponseFor($whatListMethodsReturns);
         $this->httpAdapter->setResponse($response);
 
         // system.multicall() will then return only an int
@@ -524,20 +539,22 @@ class ClientTest extends TestCase
     {
         // system.listMethods() will return ['foo', 'bar']
         $whatListMethodsReturns = ['foo', 'bar'];
-        $response = $this->getServerResponseFor($whatListMethodsReturns);
+        $response               = $this->getServerResponseFor($whatListMethodsReturns);
         $this->httpAdapter->setResponse($response);
 
         // system.multicall() will then return [fooSignatures, barSignatures]
-        $fooSignatures = [['int'], ['int', 'string']];
-        $barSignatures = [['boolean']];
+        $fooSignatures        = [['int'], ['int', 'string']];
+        $barSignatures        = [['boolean']];
         $whatMulticallReturns = [$fooSignatures, $barSignatures];
-        $response = $this->getServerResponseFor($whatMulticallReturns);
+        $response             = $this->getServerResponseFor($whatMulticallReturns);
         $this->httpAdapter->addResponse($response);
 
         $i = $this->xmlrpcClient->getIntrospector();
 
-        $expected = ['foo' => $fooSignatures,
-                          'bar' => $barSignatures];
+        $expected = [
+            'foo' => $fooSignatures,
+            'bar' => $barSignatures,
+        ];
         $this->assertEquals($expected, $i->getSignatureForEachMethod());
 
         $request = $this->xmlrpcClient->getLastRequest();
@@ -564,9 +581,9 @@ class ClientTest extends TestCase
      */
     public function testSettingNoHttpClientUriForcesClientToSetUri()
     {
-        $baseUri = 'http://foo:80/';
+        $baseUri           = 'http://foo:80/';
         $this->httpAdapter = new Adapter\Test();
-        $this->httpClient = new HttpClient(null, ['adapter' => $this->httpAdapter]);
+        $this->httpClient  = new HttpClient(null, ['adapter' => $this->httpAdapter]);
 
         $this->xmlrpcClient = new Client($baseUri);
         $this->xmlrpcClient->setHttpClient($this->httpClient);
@@ -654,7 +671,6 @@ class ClientTest extends TestCase
         $signature = $introspector->getMethodSignature('add');
     }
 
-
     /**
      * @group Laminas-8580
      */
@@ -668,7 +684,7 @@ class ClientTest extends TestCase
              ->with('get')
              ->will($this->returnValue([
                  ['parameters' => ['int']],
-                 ['parameters' => ['array']]
+                 ['parameters' => ['array']],
              ]));
 
         $expectedResult = 'array';
@@ -693,9 +709,9 @@ class ClientTest extends TestCase
      */
     public function testHandlesLeadingOrTrailingWhitespaceInChunkedResponseProperly()
     {
-        $baseUri = "http://foo:80";
+        $baseUri           = "http://foo:80";
         $this->httpAdapter = new Adapter\Test();
-        $this->httpClient = new HttpClient(null, ['adapter' => $this->httpAdapter]);
+        $this->httpClient  = new HttpClient(null, ['adapter' => $this->httpAdapter]);
 
         $respBody = file_get_contents(dirname(__FILE__) . "/_files/Laminas1897-response-chunked.txt");
         $this->httpAdapter->setResponse($respBody);
@@ -719,17 +735,17 @@ class ClientTest extends TestCase
         $response->setReturnValue($nativeVars);
         $xml = $response->saveXml();
 
-        $response = $this->makeHttpResponseFrom($xml);
-        return $response;
+        return $this->makeHttpResponseFrom($xml);
     }
 
     public function makeHttpResponseFrom($data, $status = 200, $message = 'OK')
     {
-        $headers = ["HTTP/1.1 $status $message",
-                         "Status: $status",
-                         'Content-Type: text/xml; charset=utf-8',
-                         'Content-Length: ' . strlen($data)
-                         ];
+        $headers = [
+            "HTTP/1.1 $status $message",
+            "Status: $status",
+            'Content-Type: text/xml; charset=utf-8',
+            'Content-Length: ' . strlen($data),
+        ];
         return implode("\r\n", $headers) . "\r\n\r\n$data\r\n\r\n";
     }
 

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 use Laminas\Http\Client as HttpClient;

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -55,8 +55,6 @@ class ClientTest extends TestCase
         $this->xmlrpcClient->setHttpClient($this->httpClient);
     }
 
-    // HTTP Client
-
     public function testGettingDefaultHttpClient()
     {
         $xmlrpcClient = new Client('http://foo');
@@ -81,8 +79,6 @@ class ClientTest extends TestCase
         $httpClient   = $xmlrpcClient->getHttpClient();
         $this->assertSame($this->httpClient, $httpClient);
     }
-
-    // Request & Response
 
     public function testLastRequestAndResponseAreInitiallyNull()
     {
@@ -291,10 +287,6 @@ class ClientTest extends TestCase
         $this->assertSame('foo', $this->xmlrpcClient->call('test.method'));
     }
 
-    /**#@-*/
-
-    // Faults
-
     public function testRpcMethodCallThrowsOnHttpFailure()
     {
         $status  = 404;
@@ -326,8 +318,6 @@ class ClientTest extends TestCase
         $this->expectExceptionCode($code);
         $this->xmlrpcClient->call('foo');
     }
-
-    // Server Proxy
 
     public function testGetProxyReturnsServerProxy()
     {
@@ -377,8 +367,6 @@ class ClientTest extends TestCase
         $bar = $proxy->foo->bar;
         $this->assertSame($bar, $proxy->foo->bar);
     }
-
-    // Introspection
 
     public function testGettingDefaultIntrospector()
     {
@@ -722,13 +710,19 @@ class ClientTest extends TestCase
         $this->assertEquals('FOO', $this->xmlrpcClient->call('foo'));
     }
 
-    // Helpers
+    /**
+     * @param mixed $nativeVars
+     */
     public function setServerResponseTo($nativeVars)
     {
         $response = $this->getServerResponseFor($nativeVars);
         $this->httpAdapter->setResponse($response);
     }
 
+    /**
+     * @param mixed $nativeVars
+     * @return string
+     */
     public function getServerResponseFor($nativeVars)
     {
         $response = new Response();
@@ -738,6 +732,12 @@ class ClientTest extends TestCase
         return $this->makeHttpResponseFrom($xml);
     }
 
+    /**
+     * @param string $data
+     * @param int $status
+     * @param string $message
+     * @return string
+     */
     public function makeHttpResponseFrom($data, $status = 200, $message = 'OK')
     {
         $headers = [
@@ -749,6 +749,10 @@ class ClientTest extends TestCase
         return implode("\r\n", $headers) . "\r\n\r\n$data\r\n\r\n";
     }
 
+    /**
+     * @param mixed $nativeVars
+     * @return HttpResponse
+     */
     public function makeHttpResponseFor($nativeVars)
     {
         $response = $this->getServerResponseFor($nativeVars);

--- a/test/FaultTest.php
+++ b/test/FaultTest.php
@@ -8,19 +8,19 @@
 
 namespace LaminasTest\XmlRpc;
 
+use DOMDocument;
 use Laminas\XmlRpc\AbstractValue;
 use Laminas\XmlRpc\Exception;
 use Laminas\XmlRpc\Fault;
 use PHPUnit\Framework\TestCase;
+use SimpleXMLElement;
 
 /**
  * @group      Laminas_XmlRpc
  */
 class FaultTest extends TestCase
 {
-    /**
-     * @var XmlRpc\Fault
-     */
+    /** @var XmlRpc\Fault */
     protected $fault;
 
     /**
@@ -45,7 +45,7 @@ class FaultTest extends TestCase
      */
     public function testConstructor()
     {
-        $this->assertInstanceOf('Laminas\XmlRpc\Fault', $this->fault);
+        $this->assertInstanceOf(Fault::class, $this->fault);
         $this->assertEquals(404, $this->fault->getCode());
         $this->assertEquals('Unknown Error', $this->fault->getMessage());
     }
@@ -70,11 +70,11 @@ class FaultTest extends TestCase
 
     protected function createXml()
     {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom      = new DOMDocument('1.0', 'UTF-8');
         $response = $dom->appendChild($dom->createElement('methodResponse'));
-        $fault  = $response->appendChild($dom->createElement('fault'));
-        $value  = $fault->appendChild($dom->createElement('value'));
-        $struct = $value->appendChild($dom->createElement('struct'));
+        $fault    = $response->appendChild($dom->createElement('fault'));
+        $value    = $fault->appendChild($dom->createElement('value'));
+        $struct   = $value->appendChild($dom->createElement('struct'));
 
         $member1 = $struct->appendChild($dom->createElement('member'));
         $member1->appendChild($dom->createElement('name', 'faultCode'));
@@ -91,11 +91,11 @@ class FaultTest extends TestCase
 
     protected function createNonStandardXml()
     {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom      = new DOMDocument('1.0', 'UTF-8');
         $response = $dom->appendChild($dom->createElement('methodResponse'));
-        $fault  = $response->appendChild($dom->createElement('fault'));
-        $value  = $fault->appendChild($dom->createElement('value'));
-        $struct = $value->appendChild($dom->createElement('struct'));
+        $fault    = $response->appendChild($dom->createElement('fault'));
+        $value    = $fault->appendChild($dom->createElement('value'));
+        $struct   = $value->appendChild($dom->createElement('struct'));
 
         $member1 = $struct->appendChild($dom->createElement('member'));
         $member1->appendChild($dom->createElement('name', 'faultCode'));
@@ -196,7 +196,7 @@ class FaultTest extends TestCase
      */
     protected function assertXmlFault($xml)
     {
-        $sx = new \SimpleXMLElement($xml);
+        $sx = new SimpleXMLElement($xml);
 
         $this->assertNotFalse($sx->fault, $xml);
         $this->assertNotFalse($sx->fault->value, $xml);

--- a/test/FaultTest.php
+++ b/test/FaultTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 use DOMDocument;

--- a/test/FaultTest.php
+++ b/test/FaultTest.php
@@ -68,6 +68,9 @@ class FaultTest extends TestCase
         $this->assertEquals('Message', $this->fault->getMessage());
     }
 
+    /**
+     * @return bool|string
+     */
     protected function createXml()
     {
         $dom      = new DOMDocument('1.0', 'UTF-8');
@@ -89,6 +92,9 @@ class FaultTest extends TestCase
         return $dom->saveXml();
     }
 
+    /**
+     * @return bool|string
+     */
     protected function createNonStandardXml()
     {
         $dom      = new DOMDocument('1.0', 'UTF-8');
@@ -206,11 +212,11 @@ class FaultTest extends TestCase
             $count++;
             $this->assertNotFalse($member->name, $xml);
             $this->assertNotFalse($member->value, $xml);
-            if ('faultCode' == (string) $member->name) {
+            if ('faultCode' === (string) $member->name) {
                 $this->assertNotFalse($member->value->int, $xml);
                 $this->assertEquals(1000, (int) $member->value->int, $xml);
             }
-            if ('faultString' == (string) $member->name) {
+            if ('faultString' === (string) $member->name) {
                 $this->assertNotFalse($member->value->string, $xml);
                 $this->assertEquals('Fault message', (string) $member->value->string, $xml);
             }

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -20,7 +20,7 @@ use function trim;
 class GeneratorTest extends TestCase
 {
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testCreatingSingleElement(Generator $generator)
     {
@@ -30,7 +30,7 @@ class GeneratorTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testCreatingSingleElementWithValue(Generator $generator)
     {
@@ -40,7 +40,7 @@ class GeneratorTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testCreatingComplexXmlDocument(Generator $generator)
     {
@@ -57,7 +57,7 @@ class GeneratorTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testFlushingGeneratorFlushesEverything(Generator $generator)
     {
@@ -68,7 +68,7 @@ class GeneratorTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testSpecialCharsAreEncoded(Generator $generator)
     {
@@ -83,7 +83,7 @@ class GeneratorTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGeneratorsWithAlternateEncodings
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGeneratorsWithAlternateEncodings
      */
     public function testDifferentEncodings(Generator $generator)
     {
@@ -92,7 +92,7 @@ class GeneratorTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testFluentInterfacesProvided(Generator $generator)
     {

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 use Laminas\XmlRpc\Generator\GeneratorInterface as Generator;

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -12,6 +12,8 @@ use Laminas\XmlRpc\Generator\GeneratorInterface as Generator;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 
+use function trim;
+
 /**
  * @group      Laminas_XmlRpc
  */

--- a/test/GeneratorTest.php
+++ b/test/GeneratorTest.php
@@ -100,7 +100,7 @@ class GeneratorTest extends TestCase
         $this->assertSame($generator, $generator->closeElement('foo'));
     }
 
-    public function assertXml($expected, $actual)
+    public function assertXml(string $expected, Generator $actual)
     {
         $expected = trim($expected);
         $this->assertSame($expected, trim($actual));

--- a/test/PhpInputMock.php
+++ b/test/PhpInputMock.php
@@ -1,10 +1,4 @@
 <?php // @codingStandardsIgnoreFile
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 /**

--- a/test/Request/HttpTest.php
+++ b/test/Request/HttpTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\Request;
 
 use Laminas\XmlRpc\Request;

--- a/test/Request/HttpTest.php
+++ b/test/Request/HttpTest.php
@@ -12,6 +12,9 @@ use Laminas\XmlRpc\Request;
 use LaminasTest\XmlRpc\PhpInputMock;
 use PHPUnit\Framework\TestCase;
 
+use function strlen;
+use function substr;
+
 /**
  * @group      Laminas_XmlRpc
  */
@@ -22,7 +25,7 @@ class HttpTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->xml = <<<EOX
+        $this->xml     = <<<EOX
 <?xml version="1.0" encoding="UTF-8"?>
 <methodCall>
     <methodName>test.userUpdate</methodName>
@@ -90,14 +93,14 @@ EOX;
             'User-Agent'     => 'Laminas_XmlRpc_Client',
             'Host'           => 'localhost',
             'Content-Type'   => 'text/xml',
-            'Content-Length' => 961
+            'Content-Length' => 961,
         ];
         $this->assertEquals($expected, $this->request->getHeaders());
     }
 
     public function testGetFullRequest()
     {
-        $expected = <<<EOT
+        $expected  = <<<EOT
 User-Agent: Laminas_XmlRpc_Client
 Host: localhost
 Content-Type: text/xml
@@ -119,8 +122,8 @@ EOT;
     public function testHttpRequestReadsFromPhpInput()
     {
         $this->assertNull(PhpInputMock::argumentsPassedTo('stream_open'));
-        $request = new Request\Http();
-        list($path, $mode) = PhpInputMock::argumentsPassedTo('stream_open');
+        $request       = new Request\Http();
+        [$path, $mode] = PhpInputMock::argumentsPassedTo('stream_open');
         $this->assertSame('php://input', $path);
         $this->assertSame('rb', $mode);
         $this->assertSame($this->xml, $request->getRawRequest());

--- a/test/Request/HttpTest.php
+++ b/test/Request/HttpTest.php
@@ -61,7 +61,7 @@ EOX;
 
         $this->server = $_SERVER;
         foreach ($_SERVER as $key => $value) {
-            if ('HTTP_' == substr($key, 0, 5)) {
+            if ('HTTP_' === substr($key, 0, 5)) {
                 unset($_SERVER[$key]);
             }
         }

--- a/test/Request/TestAsset/HTTPTestExtension.php
+++ b/test/Request/TestAsset/HTTPTestExtension.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\Request\TestAsset;
 
 use Laminas\XmlRpc\Request\Http;

--- a/test/Request/TestAsset/HTTPTestExtension.php
+++ b/test/Request/TestAsset/HTTPTestExtension.php
@@ -12,6 +12,10 @@ use Laminas\XmlRpc\Request\Http;
 
 class HTTPTestExtension extends Http
 {
+    /**
+     * @param mixed $method
+     * @param mixed $params
+     */
     public function __construct($method = null, $params = null)
     {
         $this->method = $method;

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -267,9 +267,9 @@ class RequestTest extends TestCase
      * helper for saveXml() and __toString() tests
      *
      * @param string $xml
-     * @return void
+     * @param array $argv
      */
-    protected function assertXmlRequest($xml, $argv)
+    protected function assertXmlRequest($xml, $argv): void
     {
         $sx = new SimpleXMLElement($xml);
 

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 use DOMDocument;

--- a/test/RequestTest.php
+++ b/test/RequestTest.php
@@ -8,10 +8,24 @@
 
 namespace LaminasTest\XmlRpc;
 
+use DOMDocument;
 use Laminas\XmlRpc\AbstractValue;
+use Laminas\XmlRpc\Fault;
 use Laminas\XmlRpc\Request;
 use Laminas\XmlRpc\Value;
 use PHPUnit\Framework\TestCase;
+use SimpleXMLElement;
+use stdClass;
+
+use function count;
+use function dirname;
+use function file_get_contents;
+use function is_string;
+use function realpath;
+use function sprintf;
+use function strtotime;
+use function time;
+use function var_export;
 
 /**
  * @group      Laminas_XmlRpc
@@ -20,7 +34,8 @@ class RequestTest extends TestCase
 {
     /**
      * \Laminas\XmlRpc\Request object
-     * @var \Laminas\XmlRpc\Request
+     *
+     * @var Request
      */
     protected $request;
 
@@ -56,7 +71,6 @@ class RequestTest extends TestCase
         $this->assertEquals('test/method', $this->request->getMethod());
     }
 
-
     /**
      * __construct() test
      */
@@ -68,11 +82,10 @@ class RequestTest extends TestCase
 
         $method = 'foo.bar';
         $params = ['baz', 1, ['foo' => 'bar']];
-        $r = new Request($method, $params);
+        $r      = new Request($method, $params);
         $this->assertEquals($method, $r->getMethod());
         $this->assertEquals($params, $r->getParams());
     }
-
 
     /**
      * addParam()/getParams() test
@@ -103,8 +116,8 @@ class RequestTest extends TestCase
         $time = time();
         $this->request->addParam($time, AbstractValue::XMLRPC_TYPE_DATETIME);
         $this->request->setMethod('foo.bar');
-        $xml = $this->request->saveXml();
-        $sxl = new \SimpleXMLElement($xml);
+        $xml   = $this->request->saveXml();
+        $sxl   = new SimpleXMLElement($xml);
         $param = $sxl->params->param->value;
         $type  = 'dateTime.iso8601';
         $this->assertTrue(isset($param->{$type}), var_export($param, 1));
@@ -119,7 +132,7 @@ class RequestTest extends TestCase
         $params = [
             'string1',
             true,
-            ['one', 'two']
+            ['one', 'two'],
         ];
         $this->request->setParams($params);
         $returned = $this->request->getParams();
@@ -127,7 +140,7 @@ class RequestTest extends TestCase
 
         $params = [
             'string2',
-            ['two', 'one']
+            ['two', 'one'],
         ];
         $this->request->setParams($params);
         $returned = $this->request->getParams();
@@ -151,9 +164,9 @@ class RequestTest extends TestCase
      */
     public function testLoadXml()
     {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
-        $mCall = $dom->appendChild($dom->createElement('methodCall'));
-        $mName = $mCall->appendChild($dom->createElement('methodName', 'do.Something'));
+        $dom    = new DOMDocument('1.0', 'UTF-8');
+        $mCall  = $dom->appendChild($dom->createElement('methodCall'));
+        $mName  = $mCall->appendChild($dom->createElement('methodName', 'do.Something'));
         $params = $mCall->appendChild($dom->createElement('params'));
         $param1 = $params->appendChild($dom->createElement('param'));
         $value1 = $param1->appendChild($dom->createElement('value'));
@@ -163,15 +176,13 @@ class RequestTest extends TestCase
         $value2 = $param2->appendChild($dom->createElement('value'));
         $value2->appendChild($dom->createElement('boolean', 1));
 
-
         $xml = $dom->saveXml();
-
 
         $parsed = $this->request->loadXml($xml);
         $this->assertTrue($parsed, $xml);
 
         $this->assertEquals('do.Something', $this->request->getMethod());
-        $test = ['string1', true];
+        $test   = ['string1', true];
         $params = $this->request->getParams();
         $this->assertSame($test, $params);
 
@@ -181,7 +192,7 @@ class RequestTest extends TestCase
 
     public function testPassingInvalidTypeToLoadXml()
     {
-        $this->assertFalse($this->request->loadXml(new \stdClass()));
+        $this->assertFalse($this->request->loadXml(new stdClass()));
         $this->assertTrue($this->request->isFault());
         $this->assertSame(635, $this->request->getFault()->getCode());
         $this->assertSame('Invalid XML provided to request', $this->request->getFault()->getMessage());
@@ -249,7 +260,7 @@ class RequestTest extends TestCase
         $this->assertNull($fault);
         $this->request->loadXml('foo');
         $fault = $this->request->getFault();
-        $this->assertInstanceOf('Laminas\XmlRpc\Fault', $fault);
+        $this->assertInstanceOf(Fault::class, $fault);
     }
 
     /**
@@ -260,20 +271,20 @@ class RequestTest extends TestCase
      */
     protected function assertXmlRequest($xml, $argv)
     {
-        $sx = new \SimpleXMLElement($xml);
+        $sx = new SimpleXMLElement($xml);
 
         $result = $sx->xpath('//methodName');
-        $count = count($result);
+        $count  = count($result);
         $this->assertEquals(1, $count, $xml);
 
         $result = $sx->xpath('//params');
-        $count = count($result);
+        $count  = count($result);
         $this->assertEquals(1, $count, $xml);
 
         $methodName = (string) $sx->methodName;
-        $params = [
+        $params     = [
             (string) $sx->params->param[0]->value->string,
-            (bool) $sx->params->param[1]->value->boolean
+            (bool) $sx->params->param[1]->value->boolean,
         ];
 
         $this->assertEquals('do.Something', $methodName);

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 use DOMDocument;

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -241,7 +241,10 @@ EOD;
         $this->assertEquals(652, $fault->getCode());
     }
 
-    public function trackError($error)
+    /**
+     * @param mixed $error
+     */
+    public function trackError($error): void
     {
         $this->errorOccurred = true;
     }

--- a/test/ResponseTest.php
+++ b/test/ResponseTest.php
@@ -8,10 +8,20 @@
 
 namespace LaminasTest\XmlRpc;
 
+use DOMDocument;
 use Laminas\XmlRpc\AbstractValue;
+use Laminas\XmlRpc\Fault;
 use Laminas\XmlRpc\Response;
 use PHPUnit\Framework\TestCase;
 use SimpleXMLElement;
+use stdClass;
+
+use function dirname;
+use function file_get_contents;
+use function is_string;
+use function realpath;
+use function set_error_handler;
+use function sprintf;
 
 /**
  * @group      Laminas_XmlRpc
@@ -20,13 +30,12 @@ class ResponseTest extends TestCase
 {
     /**
      * Response object
+     *
      * @var Response
      */
     protected $response;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     protected $errorOccurred = false;
 
     /**
@@ -78,7 +87,7 @@ class ResponseTest extends TestCase
     {
         $this->assertNull($this->response->getFault());
         $this->response->loadXml('foo');
-        $this->assertInstanceOf('Laminas\\XmlRpc\\Fault', $this->response->getFault());
+        $this->assertInstanceOf(Fault::class, $this->response->getFault());
     }
 
     /**
@@ -93,7 +102,7 @@ class ResponseTest extends TestCase
      */
     public function testLoadXml()
     {
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom      = new DOMDocument('1.0', 'UTF-8');
         $response = $dom->appendChild($dom->createElement('methodResponse'));
         $params   = $response->appendChild($dom->createElement('params'));
         $param    = $params->appendChild($dom->createElement('param'));
@@ -109,7 +118,7 @@ class ResponseTest extends TestCase
 
     public function testLoadXmlWithInvalidValue()
     {
-        $this->assertFalse($this->response->loadXml(new \stdClass()));
+        $this->assertFalse($this->response->loadXml(new stdClass()));
         $this->assertTrue($this->response->isFault());
         $this->assertSame(650, $this->response->getFault()->getCode());
     }
@@ -121,7 +130,7 @@ class ResponseTest extends TestCase
     {
         set_error_handler([$this, 'trackError']);
         $invalidResponse = 'foo';
-        $response = new Response();
+        $response        = new Response();
         $this->assertFalse($this->errorOccurred);
         $this->assertFalse($response->loadXml($invalidResponse));
         $this->assertFalse($this->errorOccurred);
@@ -144,10 +153,10 @@ EOD;
         $this->assertTrue($ret);
         $this->assertEquals([
             0 => [
-                'id'            => 1,
-                'name'          => 'birdy num num!',
-                'description'   => null,
-            ]
+                'id'          => 1,
+                'name'        => 'birdy num num!',
+                'description' => null,
+            ],
         ], $response->getReturnValue());
     }
 
@@ -231,7 +240,6 @@ EOD;
         $fault = $this->response->getFault();
         $this->assertEquals(652, $fault->getCode());
     }
-
 
     public function trackError($error)
     {

--- a/test/Server/CacheTest.php
+++ b/test/Server/CacheTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 use function file_exists;
 use function file_put_contents;
-use function is_writeable;
+use function is_writable;
 use function realpath;
 use function unlink;
 
@@ -60,7 +60,7 @@ class CacheTest extends TestCase
      */
     public function testGetSave()
     {
-        if (! is_writeable('./')) {
+        if (! is_writable('./')) {
             $this->markTestIncomplete('Directory no writable');
         }
 
@@ -78,7 +78,7 @@ class CacheTest extends TestCase
      */
     public function testDelete()
     {
-        if (! is_writeable('./')) {
+        if (! is_writable('./')) {
             $this->markTestIncomplete('Directory no writable');
         }
 
@@ -88,7 +88,7 @@ class CacheTest extends TestCase
 
     public function testShouldReturnFalseWithInvalidCache()
     {
-        if (! is_writeable('./')) {
+        if (! is_writable('./')) {
             $this->markTestIncomplete('Directory no writable');
         }
 

--- a/test/Server/CacheTest.php
+++ b/test/Server/CacheTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\Server;
 
 use Laminas\XmlRpc\Server;

--- a/test/Server/CacheTest.php
+++ b/test/Server/CacheTest.php
@@ -9,18 +9,27 @@
 namespace LaminasTest\XmlRpc\Server;
 
 use Laminas\XmlRpc\Server;
+use Laminas\XmlRpc\Server\Cache;
 use PHPUnit\Framework\TestCase;
+
+use function file_exists;
+use function file_put_contents;
+use function is_writeable;
+use function realpath;
+use function unlink;
 
 class CacheTest extends TestCase
 {
     /**
      * Server object
+     *
      * @var Server
      */
     protected $server;
 
     /**
      * Local file for caching
+     *
      * @var string
      */
     protected $file;
@@ -30,9 +39,9 @@ class CacheTest extends TestCase
      */
     protected function setUp(): void
     {
-        $this->file = realpath(__DIR__) . '/xmlrpc.cache';
+        $this->file   = realpath(__DIR__) . '/xmlrpc.cache';
         $this->server = new Server();
-        $this->server->setClass('Laminas\\XmlRpc\\Server\\Cache', 'cache');
+        $this->server->setClass(Cache::class, 'cache');
     }
 
     /**
@@ -57,7 +66,7 @@ class CacheTest extends TestCase
 
         $this->assertTrue(Server\Cache::save($this->file, $this->server));
         $expected = $this->server->listMethods();
-        $server = new Server();
+        $server   = new Server();
         $this->assertTrue(Server\Cache::get($this->file, $server));
         $actual = $server->listMethods();
 

--- a/test/Server/FaultTest.php
+++ b/test/Server/FaultTest.php
@@ -8,8 +8,13 @@
 
 namespace LaminasTest\XmlRpc\Server;
 
+use DOMDocument;
 use Laminas\XmlRpc\Server;
+use Laminas\XmlRpc\Server\Fault;
 use PHPUnit\Framework\TestCase;
+
+use function array_shift;
+use function trim;
 
 /**
  * @group      Laminas_XmlRpc
@@ -21,10 +26,10 @@ class FaultTest extends TestCase
      */
     public function testGetInstance()
     {
-        $e = new Server\Exception\RuntimeException('Testing fault', 411);
+        $e     = new Server\Exception\RuntimeException('Testing fault', 411);
         $fault = Server\Fault::getInstance($e);
 
-        $this->assertInstanceOf('Laminas\XmlRpc\Server\Fault', $fault);
+        $this->assertInstanceOf(Fault::class, $fault);
     }
 
     /**
@@ -33,7 +38,7 @@ class FaultTest extends TestCase
     public function testAttachFaultException()
     {
         Server\Fault::attachFaultException(TestAsset\Exception::class);
-        $e = new TestAsset\Exception('test exception', 411);
+        $e     = new TestAsset\Exception('test exception', 411);
         $fault = Server\Fault::getInstance($e);
         $this->assertEquals('test exception', $fault->getMessage());
         $this->assertEquals(411, $fault->getCode());
@@ -46,7 +51,7 @@ class FaultTest extends TestCase
         ];
         Server\Fault::attachFaultException($exceptions);
         foreach ($exceptions as $class) {
-            $e = new $class('test exception', 411);
+            $e     = new $class('test exception', 411);
             $fault = Server\Fault::getInstance($e);
             $this->assertEquals('test exception', $fault->getMessage());
             $this->assertEquals(411, $fault->getCode());
@@ -56,12 +61,13 @@ class FaultTest extends TestCase
 
     /**
      * Tests Laminas-1825
+     *
      * @return void
      */
     public function testAttachFaultExceptionAllowsForDerivativeExceptionClasses()
     {
         Server\Fault::attachFaultException(TestAsset\Exception::class);
-        $e = new TestAsset\Exception4('test exception', 411);
+        $e     = new TestAsset\Exception4('test exception', 411);
         $fault = Server\Fault::getInstance($e);
         $this->assertEquals('test exception', $fault->getMessage());
         $this->assertEquals(411, $fault->getCode());
@@ -74,7 +80,7 @@ class FaultTest extends TestCase
     public function testDetachFaultException()
     {
         Server\Fault::attachFaultException(TestAsset\Exception::class);
-        $e = new TestAsset\Exception('test exception', 411);
+        $e     = new TestAsset\Exception('test exception', 411);
         $fault = Server\Fault::getInstance($e);
         $this->assertEquals('test exception', $fault->getMessage());
         $this->assertEquals(411, $fault->getCode());
@@ -83,7 +89,6 @@ class FaultTest extends TestCase
         $this->assertEquals('Unknown error', $fault->getMessage());
         $this->assertEquals(404, $fault->getCode());
 
-
         $exceptions = [
             TestAsset\Exception::class,
             TestAsset\Exception2::class,
@@ -91,14 +96,14 @@ class FaultTest extends TestCase
         ];
         Server\Fault::attachFaultException($exceptions);
         foreach ($exceptions as $class) {
-            $e = new $class('test exception', 411);
+            $e     = new $class('test exception', 411);
             $fault = Server\Fault::getInstance($e);
             $this->assertEquals('test exception', $fault->getMessage());
             $this->assertEquals(411, $fault->getCode());
         }
         Server\Fault::detachFaultException($exceptions);
         foreach ($exceptions as $class) {
-            $e = new $class('test exception', 411);
+            $e     = new $class('test exception', 411);
             $fault = Server\Fault::getInstance($e);
             $this->assertEquals('Unknown error', $fault->getMessage());
             $this->assertEquals(404, $fault->getCode());
@@ -111,15 +116,15 @@ class FaultTest extends TestCase
     public function testAttachObserver()
     {
         Server\Fault::attachObserver(TestAsset\Observer::class);
-        $e = new Server\Exception\RuntimeException('Checking observers', 411);
-        $fault = Server\Fault::getInstance($e);
+        $e        = new Server\Exception\RuntimeException('Checking observers', 411);
+        $fault    = Server\Fault::getInstance($e);
         $observed = TestAsset\Observer::getObserved();
         TestAsset\Observer::clearObserved();
         Server\Fault::detachObserver(TestAsset\Observer::class);
 
         $this->assertNotEmpty($observed);
         $f = array_shift($observed);
-        $this->assertInstanceOf('Laminas\XmlRpc\Server\Fault', $f);
+        $this->assertInstanceOf(Fault::class, $f);
         $this->assertEquals('Checking observers', $f->getMessage());
         $this->assertEquals(411, $f->getCode());
 
@@ -132,13 +137,13 @@ class FaultTest extends TestCase
     public function testDetachObserver()
     {
         Server\Fault::attachObserver(TestAsset\Observer::class);
-        $e = new Server\Exception\RuntimeException('Checking observers', 411);
+        $e     = new Server\Exception\RuntimeException('Checking observers', 411);
         $fault = Server\Fault::getInstance($e);
         TestAsset\Observer::clearObserved();
         Server\Fault::detachObserver(TestAsset\Observer::class);
 
-        $e = new Server\Exception\RuntimeException('Checking observers', 411);
-        $fault = Server\Fault::getInstance($e);
+        $e        = new Server\Exception\RuntimeException('Checking observers', 411);
+        $fault    = Server\Fault::getInstance($e);
         $observed = TestAsset\Observer::getObserved();
         $this->assertEmpty($observed);
 
@@ -150,7 +155,7 @@ class FaultTest extends TestCase
      */
     public function testGetCode()
     {
-        $e = new Server\Exception\RuntimeException('Testing fault', 411);
+        $e     = new Server\Exception\RuntimeException('Testing fault', 411);
         $fault = Server\Fault::getInstance($e);
 
         $this->assertEquals(411, $fault->getCode());
@@ -161,7 +166,7 @@ class FaultTest extends TestCase
      */
     public function testGetException()
     {
-        $e = new Server\Exception\RuntimeException('Testing fault', 411);
+        $e     = new Server\Exception\RuntimeException('Testing fault', 411);
         $fault = Server\Fault::getInstance($e);
 
         $this->assertSame($e, $fault->getException());
@@ -172,7 +177,7 @@ class FaultTest extends TestCase
      */
     public function testGetMessage()
     {
-        $e = new Server\Exception\RuntimeException('Testing fault', 411);
+        $e     = new Server\Exception\RuntimeException('Testing fault', 411);
         $fault = Server\Fault::getInstance($e);
 
         $this->assertEquals('Testing fault', $fault->getMessage());
@@ -183,25 +188,25 @@ class FaultTest extends TestCase
      */
     public function testCastsFaultsToString()
     {
-        $dom  = new \DOMDocument('1.0', 'UTF-8');
-        $r    = $dom->appendChild($dom->createElement('methodResponse'));
-        $f    = $r->appendChild($dom->createElement('fault'));
-        $v    = $f->appendChild($dom->createElement('value'));
-        $s    = $v->appendChild($dom->createElement('struct'));
+        $dom = new DOMDocument('1.0', 'UTF-8');
+        $r   = $dom->appendChild($dom->createElement('methodResponse'));
+        $f   = $r->appendChild($dom->createElement('fault'));
+        $v   = $f->appendChild($dom->createElement('value'));
+        $s   = $v->appendChild($dom->createElement('struct'));
 
-        $m1   = $s->appendChild($dom->createElement('member'));
+        $m1 = $s->appendChild($dom->createElement('member'));
         $m1->appendChild($dom->createElement('name', 'faultCode'));
-        $cv   = $m1->appendChild($dom->createElement('value'));
+        $cv = $m1->appendChild($dom->createElement('value'));
         $cv->appendChild($dom->createElement('int', 411));
 
-        $m2   = $s->appendChild($dom->createElement('member'));
+        $m2 = $s->appendChild($dom->createElement('member'));
         $m2->appendChild($dom->createElement('name', 'faultString'));
-        $sv   = $m2->appendChild($dom->createElement('value'));
+        $sv = $m2->appendChild($dom->createElement('value'));
         $sv->appendChild($dom->createElement('string', 'Testing fault'));
 
         $xml = $dom->saveXML();
 
-        $e = new Server\Exception\RuntimeException('Testing fault', 411);
+        $e     = new Server\Exception\RuntimeException('Testing fault', 411);
         $fault = Server\Fault::getInstance($e);
         $fault->setEncoding('UTF-8');
 

--- a/test/Server/FaultTest.php
+++ b/test/Server/FaultTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\Server;
 
 use DOMDocument;

--- a/test/Server/TestAsset/Exception.php
+++ b/test/Server/TestAsset/Exception.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\Server\TestAsset;
 
 class Exception extends \Exception

--- a/test/Server/TestAsset/Exception2.php
+++ b/test/Server/TestAsset/Exception2.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\Server\TestAsset;
 
 use Exception;

--- a/test/Server/TestAsset/Exception2.php
+++ b/test/Server/TestAsset/Exception2.php
@@ -8,6 +8,8 @@
 
 namespace LaminasTest\XmlRpc\Server\TestAsset;
 
-class Exception2 extends \Exception
+use Exception;
+
+class Exception2 extends Exception
 {
 }

--- a/test/Server/TestAsset/Exception3.php
+++ b/test/Server/TestAsset/Exception3.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\Server\TestAsset;
 
 use Exception;

--- a/test/Server/TestAsset/Exception3.php
+++ b/test/Server/TestAsset/Exception3.php
@@ -8,6 +8,8 @@
 
 namespace LaminasTest\XmlRpc\Server\TestAsset;
 
-class Exception3 extends \Exception
+use Exception;
+
+class Exception3 extends Exception
 {
 }

--- a/test/Server/TestAsset/Exception4.php
+++ b/test/Server/TestAsset/Exception4.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\Server\TestAsset;
 
 class Exception4 extends Exception

--- a/test/Server/TestAsset/Observer.php
+++ b/test/Server/TestAsset/Observer.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\Server\TestAsset;
 
 use Laminas\XmlRpc\Server\Fault;

--- a/test/Server/TestAsset/Observer.php
+++ b/test/Server/TestAsset/Observer.php
@@ -12,15 +12,17 @@ use Laminas\XmlRpc\Server\Fault;
 
 class Observer
 {
-    private static $instance = false;
+    /** @var self|null */
+    private static $instance;
 
+    /** @var array */
     public $observed = [];
 
     private function __construct()
     {
     }
 
-    public static function getInstance()
+    public static function getInstance(): self
     {
         if (! static::$instance) {
             static::$instance = new self();
@@ -29,17 +31,17 @@ class Observer
         return static::$instance;
     }
 
-    public static function observe(Fault $fault)
+    public static function observe(Fault $fault): void
     {
         self::getInstance()->observed[] = $fault;
     }
 
-    public static function clearObserved()
+    public static function clearObserved(): void
     {
         self::getInstance()->observed = [];
     }
 
-    public static function getObserved()
+    public static function getObserved(): array
     {
         return self::getInstance()->observed;
     }

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 use Laminas\Server\Definition as ServerDefinition;

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -9,6 +9,7 @@
 namespace LaminasTest\XmlRpc;
 
 use Laminas\Server\Definition as ServerDefinition;
+use Laminas\Server\Exception\InvalidArgumentException as ServerInvalidArgumentException;
 use Laminas\Server\Method\Definition as MethodDefinition;
 use Laminas\XmlRpc\AbstractValue;
 use Laminas\XmlRpc\Exception\ExceptionInterface;
@@ -17,7 +18,6 @@ use Laminas\XmlRpc\Fault;
 use Laminas\XmlRpc\Request;
 use Laminas\XmlRpc\Response;
 use Laminas\XmlRpc\Server;
-use Laminas\XmlRpc\Server\Exception\InvalidArgumentException as ServerInvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -9,14 +9,15 @@
 namespace LaminasTest\XmlRpc;
 
 use Laminas\Server\Definition as ServerDefinition;
-use Laminas\Server\Exception\InvalidArgumentException;
 use Laminas\Server\Method\Definition as MethodDefinition;
 use Laminas\XmlRpc\AbstractValue;
-use Laminas\XmlRpc\Exception;
+use Laminas\XmlRpc\Exception\ExceptionInterface;
+use Laminas\XmlRpc\Exception\InvalidArgumentException;
 use Laminas\XmlRpc\Fault;
 use Laminas\XmlRpc\Request;
 use Laminas\XmlRpc\Response;
 use Laminas\XmlRpc\Server;
+use Laminas\XmlRpc\Server\Exception\InvalidArgumentException as ServerInvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
@@ -57,6 +58,11 @@ class ServerTest extends TestCase
         unset($this->server);
     }
 
+    /**
+     * @param string $errno
+     * @param string $errstr
+     * @return bool|void
+     */
     public function suppressNotFoundWarnings($errno, $errstr)
     {
         if (! strstr($errstr, 'failed')) {
@@ -93,7 +99,7 @@ class ServerTest extends TestCase
 
     public function testAddFunctionThrowsExceptionOnInvalidInput()
     {
-        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to attach function; invalid');
         $this->server->addFunction('nosuchfunction');
     }
@@ -305,7 +311,7 @@ class ServerTest extends TestCase
         $help = $this->server->methodHelp('system.methodHelp', 'system.listMethods');
         $this->assertStringContainsString('Display help message for an XMLRPC method', $help);
 
-        $this->expectException(Server\Exception\ExceptionInterface::class);
+        $this->expectException(ExceptionInterface::class);
         $this->expectExceptionMessage('Method "foo" does not exist');
         $this->server->methodHelp('foo');
     }
@@ -326,7 +332,7 @@ class ServerTest extends TestCase
         $this->assertIsArray($sig);
         $this->assertEquals(1, count($sig), var_export($sig, 1));
 
-        $this->expectException(Server\Exception\ExceptionInterface::class);
+        $this->expectException(ExceptionInterface::class);
         $this->expectExceptionMessage('Method "foo" does not exist');
         $this->server->methodSignature('foo');
     }
@@ -452,7 +458,7 @@ class ServerTest extends TestCase
     public function testAddFunctionThrowsExceptionWithBadData()
     {
         $o = new stdClass();
-        $this->expectException(Server\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unable to attach function; invalid');
         $this->server->addFunction($o);
     }
@@ -460,7 +466,7 @@ class ServerTest extends TestCase
     public function testLoadFunctionsThrowsExceptionWithBadData()
     {
         $o = new stdClass();
-        $this->expectException(Server\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'Unable to load server definition; must be an array or Laminas\Server\Definition, received stdClass'
         );
@@ -469,7 +475,7 @@ class ServerTest extends TestCase
 
     public function testLoadFunctionsThrowsExceptionsWithBadData2()
     {
-        $this->expectException(Server\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             'Unable to load server definition; must be an array or Laminas\Server\Definition, received string'
         );
@@ -481,7 +487,7 @@ class ServerTest extends TestCase
         $o = new stdClass();
         $o = [$o];
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(ServerInvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid method provided');
         $this->server->loadFunctions($o);
     }
@@ -505,7 +511,7 @@ class ServerTest extends TestCase
 
     public function testSetClassThrowsExceptionWithInvalidClass()
     {
-        $this->expectException(Server\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid method class');
         $this->server->setClass('mybogusclass');
     }
@@ -522,14 +528,14 @@ class ServerTest extends TestCase
      */
     public function testSetRequestThrowsExceptionOnBadClassName()
     {
-        $this->expectException(Server\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid request object');
         $this->server->setRequest('LaminasTest\\XmlRpc\\TestRequest2');
     }
 
     public function testSetRequestThrowsExceptionOnBadObject()
     {
-        $this->expectException(Server\Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid request object');
         $this->server->setRequest($this);
     }
@@ -648,7 +654,7 @@ class ServerTest extends TestCase
 
     public function testCallingUnregisteredMethod()
     {
-        $this->expectException(Server\Exception\ExceptionInterface::class);
+        $this->expectException(ExceptionInterface::class);
         $this->expectExceptionMessage('Unknown instance method called on server: foobarbaz');
         $this->server->foobarbaz();
     }
@@ -661,14 +667,14 @@ class ServerTest extends TestCase
 
     public function testPassingInvalidRequestClassThrowsException()
     {
-        $this->expectException(Server\Exception\ExceptionInterface::class);
+        $this->expectException(ExceptionInterface::class);
         $this->expectExceptionMessage('Invalid request class');
         $this->server->setRequest('stdClass');
     }
 
     public function testPassingInvalidResponseClassThrowsException()
     {
-        $this->expectException(Server\Exception\ExceptionInterface::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid response class');
         $this->server->setResponseClass('stdClass');
     }

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -17,9 +17,16 @@ use Laminas\XmlRpc\Fault;
 use Laminas\XmlRpc\Request;
 use Laminas\XmlRpc\Response;
 use Laminas\XmlRpc\Server;
-use Laminas\XmlRpc\Value;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+
+use function base64_encode;
+use function count;
+use function ob_end_clean;
+use function ob_get_contents;
+use function ob_start;
+use function strstr;
+use function var_export;
 
 /**
  * @group      Laminas_XmlRpc
@@ -28,6 +35,7 @@ class ServerTest extends TestCase
 {
     /**
      * Server object
+     *
      * @var Server
      */
     protected $server;
@@ -108,7 +116,7 @@ class ServerTest extends TestCase
         $expected = $this->server->listMethods();
 
         $functions = $this->server->getFunctions();
-        $server = new Server();
+        $server    = new Server();
         $server->loadFunctions($functions);
         $actual = $server->listMethods();
 
@@ -138,11 +146,11 @@ class ServerTest extends TestCase
         $request = new Request();
         $request->setMethod('test.test4');
         $response = $this->server->handle($request);
-        $this->assertNotInstanceOf('Laminas\\XmlRpc\\Fault', $response);
+        $this->assertNotInstanceOf(Fault::class, $response);
         $this->assertSame([
             'test1' => 'argv-argument',
             'test2' => null,
-            'arg' => ['argv-argument']
+            'arg'   => ['argv-argument'],
         ], $response->getReturnValue());
     }
 
@@ -156,7 +164,7 @@ class ServerTest extends TestCase
         $request->setMethod('test.test4');
         $request->setParams(['foo']);
         $response = $this->server->handle($request);
-        $this->assertNotInstanceOf('Laminas\\XmlRpc\\Fault', $response);
+        $this->assertNotInstanceOf(Fault::class, $response);
         $this->assertSame(['test1' => 'a1', 'test2' => 'a2', 'arg' => ['foo']], $response->getReturnValue());
     }
 
@@ -166,12 +174,12 @@ class ServerTest extends TestCase
     public function testFault()
     {
         $fault = $this->server->fault('This is a fault', 411);
-        $this->assertInstanceOf('Laminas\XmlRpc\Server\Fault', $fault);
+        $this->assertInstanceOf(\Laminas\XmlRpc\Server\Fault::class, $fault);
         $this->assertEquals(411, $fault->getCode());
         $this->assertEquals('This is a fault', $fault->getMessage());
 
         $fault = $this->server->fault(new Server\Exception\RuntimeException('Exception fault', 511));
-        $this->assertInstanceOf('Laminas\XmlRpc\Server\Fault', $fault);
+        $this->assertInstanceOf(\Laminas\XmlRpc\Server\Fault::class, $fault);
         $this->assertEquals(511, $fault->getCode());
         $this->assertEquals('Exception fault', $fault->getMessage());
     }
@@ -186,13 +194,13 @@ class ServerTest extends TestCase
         $this->server->setReturnResponse(false);
         ob_start();
         $response = $this->server->handle($request);
-        $output = ob_get_contents();
+        $output   = ob_get_contents();
         ob_end_clean();
         $this->server->setReturnResponse(true);
 
         $this->assertFalse(isset($response));
         $response = $this->server->getResponse();
-        $this->assertInstanceOf('Laminas\XmlRpc\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertSame($response->__toString(), $output);
         $return = $response->getReturnValue();
         $this->assertIsArray($return);
@@ -215,7 +223,7 @@ class ServerTest extends TestCase
         $request->setMethod('system.listMethods');
         $response = $this->server->handle($request);
 
-        $this->assertInstanceOf('Laminas\XmlRpc\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $return = $response->getReturnValue();
         $this->assertIsArray($return);
         $this->assertContains('system.multicall', $return);
@@ -230,7 +238,7 @@ class ServerTest extends TestCase
         $request->setMethod('system.methodHelp');
         $response = $this->server->handle($request);
 
-        $this->assertInstanceOf('Laminas\XmlRpc\Fault', $response);
+        $this->assertInstanceOf(Fault::class, $response);
         $this->assertEquals(623, $response->getCode());
     }
 
@@ -239,11 +247,10 @@ class ServerTest extends TestCase
         $request = new Request();
         $request->setMethod('invalid');
         $response = $this->server->handle($request);
-        $this->assertInstanceOf('Laminas\\XmlRpc\\Fault', $response);
+        $this->assertInstanceOf(Fault::class, $response);
         $this->assertSame('Method "invalid" does not exist', $response->getMessage());
         $this->assertSame(620, $response->getCode());
     }
-
 
     /**
      * setResponseClass() test
@@ -262,7 +269,7 @@ class ServerTest extends TestCase
         $request->setMethod('system.listMethods');
         $response = $this->server->handle($request);
 
-        $this->assertInstanceOf('Laminas\XmlRpc\Response', $response);
+        $this->assertInstanceOf(Response::class, $response);
         $this->assertInstanceOf(TestAsset\TestResponse::class, $response);
     }
 
@@ -336,15 +343,15 @@ class ServerTest extends TestCase
      */
     public function testMulticall()
     {
-        $struct = [
+        $struct  = [
             [
                 'methodName' => 'system.listMethods',
-                'params' => []
+                'params'     => [],
             ],
             [
                 'methodName' => 'system.methodHelp',
-                'params' => ['system.multicall']
-            ]
+                'params'     => ['system.multicall'],
+            ],
         ];
         $request = new Request();
         $request->setMethod('system.multicall');
@@ -352,7 +359,7 @@ class ServerTest extends TestCase
         $response = $this->server->handle($request);
 
         $this->assertInstanceOf(
-            'Laminas\XmlRpc\Response',
+            Response::class,
             $response,
             $response->__toString() . "\n\n" . $request->__toString()
         );
@@ -368,15 +375,15 @@ class ServerTest extends TestCase
      */
     public function testMulticallHandlesFaults()
     {
-        $struct = [
+        $struct  = [
             [
                 'methodName' => 'system.listMethods',
-                'params' => []
+                'params'     => [],
             ],
             [
                 'methodName' => 'undefined',
-                'params' => []
-            ]
+                'params'     => [],
+            ],
         ];
         $request = new Request();
         $request->setMethod('system.multicall');
@@ -384,7 +391,7 @@ class ServerTest extends TestCase
         $response = $this->server->handle($request);
 
         $this->assertInstanceOf(
-            'Laminas\XmlRpc\Response',
+            Response::class,
             $response,
             $response->__toString() . "\n\n" . $request->__toString()
         );
@@ -393,8 +400,8 @@ class ServerTest extends TestCase
         $this->assertEquals(2, count($returns), var_export($returns, 1));
         $this->assertIsArray($returns[0], var_export($returns[0], 1));
         $this->assertSame([
-            'faultCode' => 620,
-            'faultString' => 'Method "undefined" does not exist'
+            'faultCode'   => 620,
+            'faultString' => 'Method "undefined" does not exist',
         ], $returns[1], var_export($returns[1], 1));
     }
 
@@ -481,7 +488,7 @@ class ServerTest extends TestCase
 
     public function testLoadFunctionsReadsMethodsFromServerDefinitionObjects()
     {
-        $mockedMethod = $this->getMockBuilder(MethodDefinition::class)
+        $mockedMethod     = $this->getMockBuilder(MethodDefinition::class)
             ->disableOriginalConstructor()
             ->disableOriginalClone()
             ->getMock();
@@ -534,7 +541,7 @@ class ServerTest extends TestCase
         $request->setMethod('test1');
         $request->addParam('value');
         $response = $this->server->handle($request);
-        $this->assertNotInstanceOf('Laminas\XmlRpc\Fault', $response);
+        $this->assertNotInstanceOf(Fault::class, $response);
         $this->assertEquals('String: value', $response->getReturnValue());
     }
 
@@ -545,7 +552,7 @@ class ServerTest extends TestCase
         $request->setMethod('test2');
         $request->addParam(['value1', 'value2']);
         $response = $this->server->handle($request);
-        $this->assertNotInstanceOf('Laminas\XmlRpc\Fault', $response);
+        $this->assertNotInstanceOf(Fault::class, $response);
         $this->assertEquals('value1; value2', $response->getReturnValue());
     }
 
@@ -556,29 +563,29 @@ class ServerTest extends TestCase
         $request->setMethod('LaminasTest\\XmlRpc\\TestAsset\\testFunction');
         $request->setParams([['value1'], 'key']);
         $response = $this->server->handle($request);
-        $this->assertNotInstanceOf('Laminas\XmlRpc\Fault', $response);
+        $this->assertNotInstanceOf(Fault::class, $response);
         $this->assertEquals('key: value1', $response->getReturnValue());
     }
 
     public function testMulticallReturnsFaultsWithBadData()
     {
         // bad method array
-        $try = [
+        $try      = [
             'system.listMethods',
             [
-                'name' => 'system.listMethods'
-            ],
-            [
-                'methodName' => 'system.listMethods'
+                'name' => 'system.listMethods',
             ],
             [
                 'methodName' => 'system.listMethods',
-                'params'     => ''
+            ],
+            [
+                'methodName' => 'system.listMethods',
+                'params'     => '',
             ],
             [
                 'methodName' => 'system.multicall',
-                'params'     => []
-            ]
+                'params'     => [],
+            ],
         ];
         $returned = $this->server->multicall($try);
         $this->assertIsArray($returned);
@@ -621,7 +628,7 @@ class ServerTest extends TestCase
         $request = new Request('test.base64', [$param]);
 
         $response = $this->server->handle($request);
-        $this->assertNotInstanceOf('Laminas\XmlRpc\Fault', $response);
+        $this->assertNotInstanceOf(Fault::class, $response);
         $this->assertEquals($data, $response->getReturnValue());
     }
 
@@ -632,7 +639,7 @@ class ServerTest extends TestCase
     {
         $server = new Server();
         $server->setClass(TestAsset\TestClass::class);
-        $table = $server->getDispatchTable();
+        $table  = $server->getDispatchTable();
         $method = $table->getMethod('test1');
         foreach ($method->getPrototypes() as $prototype) {
             $this->assertNotEquals('void', $prototype->getReturnType(), var_export($prototype, 1));

--- a/test/TestAsset/PythonSimpleXMLRPCServerWithUnsupportedIntrospection.php
+++ b/test/TestAsset/PythonSimpleXMLRPCServerWithUnsupportedIntrospection.php
@@ -15,9 +15,14 @@ use Laminas\XmlRpc\Client\ServerProxy;
  */
 class PythonSimpleXMLRPCServerWithUnsupportedIntrospection extends ServerProxy
 {
+    /**
+     * @param string $method
+     * @param array $args
+     * @return mixed
+     */
     public function __call($method, $args)
     {
-        if ($method == 'methodSignature') {
+        if ($method === 'methodSignature') {
             return 'signatures not supported';
         }
         return parent::__call($method, $args);

--- a/test/TestAsset/PythonSimpleXMLRPCServerWithUnsupportedIntrospection.php
+++ b/test/TestAsset/PythonSimpleXMLRPCServerWithUnsupportedIntrospection.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\TestAsset;
 
 use Laminas\XmlRpc\Client\ServerProxy;

--- a/test/TestAsset/SerializableTestClass.php
+++ b/test/TestAsset/SerializableTestClass.php
@@ -10,14 +10,15 @@ namespace LaminasTest\XmlRpc\TestAsset;
 
 class SerializableTestClass
 {
+    /** @var string */
     protected $property;
 
-    public function setProperty($property)
+    public function setProperty(string $property): void
     {
         $this->property = $property;
     }
 
-    public function getProperty()
+    public function getProperty(): string
     {
         return $this->property;
     }

--- a/test/TestAsset/SerializableTestClass.php
+++ b/test/TestAsset/SerializableTestClass.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\TestAsset;
 
 class SerializableTestClass

--- a/test/TestAsset/TestClass.php
+++ b/test/TestAsset/TestClass.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\TestAsset;
 
 use function func_get_args;

--- a/test/TestAsset/TestClass.php
+++ b/test/TestAsset/TestClass.php
@@ -13,11 +13,14 @@ use function implode;
 
 class TestClass
 {
+    /** @var mixed */
     private $value1;
+    /** @var mixed */
     private $value2;
 
     /**
-     * Constructor
+     * @param mixed $value1
+     * @param mixed $value2
      */
     public function __construct($value1 = null, $value2 = null)
     {

--- a/test/TestAsset/TestClass.php
+++ b/test/TestAsset/TestClass.php
@@ -8,6 +8,9 @@
 
 namespace LaminasTest\XmlRpc\TestAsset;
 
+use function func_get_args;
+use function implode;
+
 class TestClass
 {
     private $value1;
@@ -15,7 +18,6 @@ class TestClass
 
     /**
      * Constructor
-     *
      */
     public function __construct($value1 = null, $value2 = null)
     {

--- a/test/TestAsset/TestClient.php
+++ b/test/TestAsset/TestClient.php
@@ -9,12 +9,17 @@
 namespace LaminasTest\XmlRpc\TestAsset;
 
 use Laminas\XmlRpc\Client;
+use Laminas\XmlRpc\Client\ServerProxy;
 
 /**
  * related to Laminas-8478
  */
 class TestClient extends Client
 {
+    /**
+     * @param string $namespace
+     * @return ServerProxy
+     */
     public function getProxy($namespace = '')
     {
         if (empty($this->proxyCache[$namespace])) {

--- a/test/TestAsset/TestClient.php
+++ b/test/TestAsset/TestClient.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\TestAsset;
 
 use Laminas\XmlRpc\Client;

--- a/test/TestAsset/TestRequest.php
+++ b/test/TestAsset/TestRequest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\TestAsset;
 
 use Laminas\XmlRpc\Request;

--- a/test/TestAsset/TestResponse.php
+++ b/test/TestAsset/TestResponse.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\TestAsset;
 
 use Laminas\XmlRpc\Response;

--- a/test/TestAsset/functions.php
+++ b/test/TestAsset/functions.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc\TestAsset;
 
 use function implode;

--- a/test/TestAsset/functions.php
+++ b/test/TestAsset/functions.php
@@ -8,6 +8,8 @@
 
 namespace LaminasTest\XmlRpc\TestAsset;
 
+use function implode;
+
 /**
  * testFunction
  *

--- a/test/ValueTest.php
+++ b/test/ValueTest.php
@@ -10,7 +10,8 @@ namespace LaminasTest\XmlRpc;
 
 use DateTime;
 use Laminas\XmlRpc\AbstractValue;
-use Laminas\XmlRpc\Exception;
+use Laminas\XmlRpc\Exception\InvalidArgumentException;
+use Laminas\XmlRpc\Exception\ValueException;
 use Laminas\XmlRpc\Generator\GeneratorInterface as Generator;
 use Laminas\XmlRpc\Value;
 use PHPUnit\Framework\TestCase;
@@ -35,9 +36,8 @@ use const PHP_INT_MAX;
  */
 class ValueTest extends TestCase
 {
+    /** @var string */
     public $xmlRpcDateFormat = 'Ymd\\TH:i:s';
-
-    // Boolean
 
     public function testFactoryAutodetectsBoolean()
     {
@@ -60,7 +60,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalBooleanFromXmlRpc(Generator $generator)
     {
@@ -76,8 +76,6 @@ class ValueTest extends TestCase
         $this->assertSame(true, $val->getValue());
         $this->assertEquals($this->wrapXml($xml), $val->saveXml());
     }
-
-    // Integer
 
     public function testFactoryAutodetectsInteger()
     {
@@ -101,7 +99,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalIntegerFromXmlRpc(Generator $generator)
     {
@@ -130,7 +128,7 @@ class ValueTest extends TestCase
      */
     public function testMarshalI4FromOverlongNativeThrowsException()
     {
-        $this->expectException(Exception\ValueException::class);
+        $this->expectException(ValueException::class);
         $this->expectExceptionMessage('Overlong integer given');
         $x = AbstractValue::getXmlRpcValue(PHP_INT_MAX + 5000, AbstractValue::XMLRPC_TYPE_I4);
         var_dump($x);
@@ -141,12 +139,10 @@ class ValueTest extends TestCase
      */
     public function testMarshalIntegerFromOverlongNativeThrowsException()
     {
-        $this->expectException(Exception\ValueException::class);
+        $this->expectException(ValueException::class);
         $this->expectExceptionMessage('Overlong integer given');
         AbstractValue::getXmlRpcValue(PHP_INT_MAX + 5000, AbstractValue::XMLRPC_TYPE_INTEGER);
     }
-
-    // Double
 
     public function testFactoryAutodetectsFloat()
     {
@@ -167,7 +163,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalDoubleFromXmlRpc(Generator $generator)
     {
@@ -187,7 +183,7 @@ class ValueTest extends TestCase
 
     /**
      * @group Laminas-7712
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshallingDoubleWithHigherPrecisionFromNative(Generator $generator)
     {
@@ -205,7 +201,7 @@ class ValueTest extends TestCase
 
     /**
      * @group Laminas-7712
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshallingDoubleWithHigherPrecisionFromNativeWithTrailingZeros(Generator $generator)
     {
@@ -219,8 +215,6 @@ class ValueTest extends TestCase
         $this->assertSame($native, $value->getValue());
         $this->assertSame('<value><double>0.1</double></value>', trim($value->saveXml()));
     }
-
-    // String
 
     public function testFactoryAutodetectsString()
     {
@@ -258,7 +252,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalStringFromXmlRpc(Generator $generator)
     {
@@ -277,7 +271,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalStringFromDefault(Generator $generator)
     {
@@ -294,8 +288,6 @@ class ValueTest extends TestCase
         $this->assertSame($native, $val->getValue());
         $this->assertEquals($this->wrapXml($xml), $val->saveXml());
     }
-
-    //Nil
 
     public function testFactoryAutodetectsNil()
     {
@@ -319,7 +311,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalNilFromXmlRpc(Generator $generator)
     {
@@ -341,8 +333,6 @@ class ValueTest extends TestCase
         }
     }
 
-    // Array
-
     public function testFactoryAutodetectsArray()
     {
         $val = AbstractValue::getXmlRpcValue([0, 'foo']);
@@ -362,7 +352,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalArrayFromXmlRpc(Generator $generator)
     {
@@ -383,7 +373,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testEmptyXmlRpcArrayResultsInEmptyArray(Generator $generator)
     {
@@ -407,7 +397,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testArrayMustContainDataElement(Generator $generator)
     {
@@ -415,14 +405,12 @@ class ValueTest extends TestCase
         $native = [];
         $xml    = '<value><array/></value>';
 
-        $this->expectException(Exception\ValueException::class);
+        $this->expectException(ValueException::class);
         $this->expectExceptionMessage(
             'Invalid XML for XML-RPC native array type: ARRAY tag must contain DATA tag'
         );
         $val = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
     }
-
-    // Struct
 
     public function testFactoryAutodetectsStruct()
     {
@@ -449,7 +437,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalStructFromXmlRpc(Generator $generator)
     {
@@ -471,7 +459,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshallingNestedStructFromXmlRpc(Generator $generator)
     {
@@ -493,7 +481,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshallingStructWithMemberWithoutValue(Generator $generator)
     {
@@ -517,7 +505,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshallingStructWithMemberWithoutName(Generator $generator)
     {
@@ -542,7 +530,7 @@ class ValueTest extends TestCase
 
     /**
      * @group Laminas-7639
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalStructFromXmlRpcWithEntities(Generator $generator)
     {
@@ -558,7 +546,7 @@ class ValueTest extends TestCase
 
     /**
      * @group Laminas-3947
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshallingStructsWithEmptyValueFromXmlRpcShouldRetainKeys(Generator $generator)
     {
@@ -579,7 +567,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshallingStructWithMultibyteValueFromXmlRpcRetainsMultibyteValue(Generator $generator)
     {
@@ -602,8 +590,6 @@ class ValueTest extends TestCase
         $this->assertSame($native, $val->getValue());
         $this->assertSame(trim($xml), trim($val->saveXml()));
     }
-
-    // DateTime
 
     public function testMarshalDateTimeFromNativeString()
     {
@@ -636,7 +622,7 @@ class ValueTest extends TestCase
 
     public function testMarshalDateTimeFromInvalidString()
     {
-        $this->expectException(Exception\ValueException::class);
+        $this->expectException(ValueException::class);
         $this->expectExceptionMessage('The timezone could not be found in the database');
         AbstractValue::getXmlRpcValue('foobarbaz', AbstractValue::XMLRPC_TYPE_DATETIME);
     }
@@ -665,7 +651,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalDateTimeFromXmlRpc(Generator $generator)
     {
@@ -686,7 +672,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      * @group Laminas-4249
      */
     public function testMarshalDateTimeFromFromDateTime(Generator $generator)
@@ -705,7 +691,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      * @group Laminas-4249
      */
     public function testMarshalDateTimeFromDateTimeAndAutodetectingType(Generator $generator)
@@ -738,8 +724,6 @@ class ValueTest extends TestCase
         $this->assertEquals($expectedValue, $xmlRpcValueDateTime->getValue());
     }
 
-    // Base64
-
     public function testMarshalBase64FromString()
     {
         $native = 'foo';
@@ -753,7 +737,7 @@ class ValueTest extends TestCase
     }
 
     /**
-     * @dataProvider LaminasTest\XmlRpc\TestProvider::provideGenerators
+     * @dataProvider \LaminasTest\XmlRpc\AbstractTestProvider::provideGenerators
      */
     public function testMarshalBase64FromXmlRpc(Generator $generator)
     {
@@ -817,11 +801,9 @@ class ValueTest extends TestCase
         $this->assertNotEquals($generator, AbstractValue::getGenerator());
     }
 
-    // Exceptions
-
     public function testFactoryThrowsWhenInvalidTypeSpecified()
     {
-        $this->expectException(Exception\ValueException::class);
+        $this->expectException(ValueException::class);
         $this->expectExceptionMessage('Given type is not a Laminas\XmlRpc\AbstractValue constant');
         AbstractValue::getXmlRpcValue('', 'bad type here');
     }
@@ -900,13 +882,14 @@ class ValueTest extends TestCase
 
     public function testGetXmlRpcTypeByValueThrowsExceptionOnInvalidValue()
     {
-        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         AbstractValue::getXmlRpcTypeByValue(fopen(__FILE__, 'r'));
     }
 
-    // Custom Assertions and Helper Methods
-
-    public function assertXmlRpcType($type, $object)
+    /**
+     * @param mixed $object
+     */
+    public function assertXmlRpcType(string $type, $object): void
     {
         switch ($type) {
             case 'array':
@@ -923,7 +906,7 @@ class ValueTest extends TestCase
         $this->assertInstanceOf($type, $object);
     }
 
-    public function wrapXml($xml)
+    public function wrapXml(string $xml): string
     {
         return $xml . "\n";
     }

--- a/test/ValueTest.php
+++ b/test/ValueTest.php
@@ -1,11 +1,5 @@
 <?php
 
-/**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
 namespace LaminasTest\XmlRpc;
 
 use DateTime;

--- a/test/ValueTest.php
+++ b/test/ValueTest.php
@@ -16,6 +16,18 @@ use Laminas\XmlRpc\Value;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
+use function base64_encode;
+use function fopen;
+use function ini_get;
+use function serialize;
+use function strtotime;
+use function trim;
+use function ucfirst;
+use function unserialize;
+use function var_dump;
+
+use const PHP_INT_MAX;
+
 /**
  * Test case for Value
  *
@@ -38,7 +50,7 @@ class ValueTest extends TestCase
     public function testMarshalBooleanFromNative()
     {
         $native = true;
-        $val = AbstractValue::getXmlRpcValue(
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_BOOLEAN
         );
@@ -76,8 +88,10 @@ class ValueTest extends TestCase
     public function testMarshalIntegerFromNative()
     {
         $native = 1;
-        $types = [AbstractValue::XMLRPC_TYPE_I4,
-                       AbstractValue::XMLRPC_TYPE_INTEGER];
+        $types  = [
+            AbstractValue::XMLRPC_TYPE_I4,
+            AbstractValue::XMLRPC_TYPE_INTEGER,
+        ];
 
         foreach ($types as $type) {
             $val = AbstractValue::getXmlRpcValue($native, $type);
@@ -94,8 +108,10 @@ class ValueTest extends TestCase
         AbstractValue::setGenerator($generator);
 
         $native = 1;
-        $xmls = ["<value><int>$native</int></value>",
-                      "<value><i4>$native</i4></value>"];
+        $xmls   = [
+            "<value><int>$native</int></value>",
+            "<value><i4>$native</i4></value>",
+        ];
 
         foreach ($xmls as $xml) {
             $val = AbstractValue::getXmlRpcValue(
@@ -134,14 +150,14 @@ class ValueTest extends TestCase
 
     public function testFactoryAutodetectsFloat()
     {
-        $val = AbstractValue::getXmlRpcValue((float)1);
+        $val = AbstractValue::getXmlRpcValue((float) 1);
         $this->assertXmlRpcType('double', $val);
     }
 
     public function testMarshalDoubleFromNative()
     {
         $native = 1.1;
-        $val = AbstractValue::getXmlRpcValue(
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_DOUBLE
         );
@@ -157,8 +173,8 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = 1.1;
-        $xml = "<value><double>$native</double></value>";
-        $val = AbstractValue::getXmlRpcValue(
+        $xml    = "<value><double>$native</double></value>";
+        $val    = AbstractValue::getXmlRpcValue(
             $xml,
             AbstractValue::XML_STRING
         );
@@ -181,7 +197,7 @@ class ValueTest extends TestCase
         }
 
         $native = 0.1234567;
-        $value = AbstractValue::getXmlRpcValue($native, AbstractValue::XMLRPC_TYPE_DOUBLE);
+        $value  = AbstractValue::getXmlRpcValue($native, AbstractValue::XMLRPC_TYPE_DOUBLE);
         $this->assertXmlRpcType('double', $value);
         $this->assertSame($native, $value->getValue());
         $this->assertSame('<value><double>0.1234567</double></value>', trim($value->saveXml()));
@@ -198,7 +214,7 @@ class ValueTest extends TestCase
             $this->markTestSkipped('precision is too low');
         }
         $native = 0.1;
-        $value = AbstractValue::getXmlRpcValue($native, AbstractValue::XMLRPC_TYPE_DOUBLE);
+        $value  = AbstractValue::getXmlRpcValue($native, AbstractValue::XMLRPC_TYPE_DOUBLE);
         $this->assertXmlRpcType('double', $value);
         $this->assertSame($native, $value->getValue());
         $this->assertSame('<value><double>0.1</double></value>', trim($value->saveXml()));
@@ -212,11 +228,10 @@ class ValueTest extends TestCase
         $this->assertXmlRpcType('string', $val);
     }
 
-
     public function testMarshalStringFromNative()
     {
         $native = 'foo';
-        $val = AbstractValue::getXmlRpcValue(
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_STRING
         );
@@ -249,8 +264,8 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = 'foo<>';
-        $xml = "<value><string>foo&lt;&gt;</string></value>";
-        $val = AbstractValue::getXmlRpcValue(
+        $xml    = "<value><string>foo&lt;&gt;</string></value>";
+        $val    = AbstractValue::getXmlRpcValue(
             $xml,
             AbstractValue::XML_STRING
         );
@@ -268,8 +283,8 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = 'foo<br/>bar';
-        $xml = "<string>foo&lt;br/&gt;bar</string>";
-        $val = AbstractValue::getXmlRpcValue(
+        $xml    = "<string>foo&lt;br/&gt;bar</string>";
+        $val    = AbstractValue::getXmlRpcValue(
             $xml,
             AbstractValue::XML_STRING
         );
@@ -291,8 +306,10 @@ class ValueTest extends TestCase
     public function testMarshalNilFromNative()
     {
         $native = null;
-        $types = [AbstractValue::XMLRPC_TYPE_NIL,
-                       AbstractValue::XMLRPC_TYPE_APACHENIL];
+        $types  = [
+            AbstractValue::XMLRPC_TYPE_NIL,
+            AbstractValue::XMLRPC_TYPE_APACHENIL,
+        ];
         foreach ($types as $type) {
             $value = AbstractValue::getXmlRpcValue($native, $type);
 
@@ -307,8 +324,10 @@ class ValueTest extends TestCase
     public function testMarshalNilFromXmlRpc(Generator $generator)
     {
         AbstractValue::setGenerator($generator);
-        $xmls = ['<value><nil/></value>',
-                     '<value><ex:nil xmlns:ex="http://ws.apache.org/xmlrpc/namespaces/extensions"/></value>'];
+        $xmls = [
+            '<value><nil/></value>',
+            '<value><ex:nil xmlns:ex="http://ws.apache.org/xmlrpc/namespaces/extensions"/></value>',
+        ];
 
         foreach ($xmls as $xml) {
             $val = AbstractValue::getXmlRpcValue(
@@ -332,8 +351,8 @@ class ValueTest extends TestCase
 
     public function testMarshalArrayFromNative()
     {
-        $native = [0,1];
-        $val = AbstractValue::getXmlRpcValue(
+        $native = [0, 1];
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_ARRAY
         );
@@ -348,8 +367,8 @@ class ValueTest extends TestCase
     public function testMarshalArrayFromXmlRpc(Generator $generator)
     {
         AbstractValue::setGenerator($generator);
-        $native = [0,1];
-        $xml = '<value><array><data><value><int>0</int></value>'
+        $native = [0, 1];
+        $xml    = '<value><array><data><value><int>0</int></value>'
              . '<value><int>1</int></value></data></array></value>';
 
         $val = AbstractValue::getXmlRpcValue(
@@ -413,14 +432,14 @@ class ValueTest extends TestCase
 
     public function testFactoryAutodetectsStructFromObject()
     {
-        $val = AbstractValue::getXmlRpcValue((object)['foo' => 0]);
+        $val = AbstractValue::getXmlRpcValue((object) ['foo' => 0]);
         $this->assertXmlRpcType('struct', $val);
     }
 
     public function testMarshalStructFromNative()
     {
         $native = ['foo' => 0];
-        $val = AbstractValue::getXmlRpcValue(
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_STRUCT
         );
@@ -436,7 +455,7 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = ['foo' => 0, 'bar' => 'foo<>bar'];
-        $xml = '<value><struct><member><name>foo</name><value><int>0</int>'
+        $xml    = '<value><struct><member><name>foo</name><value><int>0</int>'
              . '</value></member><member><name>bar</name><value><string>'
              . 'foo&lt;&gt;bar</string></value></member></struct></value>';
 
@@ -458,7 +477,7 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = ['foo' => ['bar' => '<br/>']];
-        $xml = '<value><struct><member><name>foo</name><value><struct><member>'
+        $xml    = '<value><struct><member><name>foo</name><value><struct><member>'
              . '<name>bar</name><value><string>&lt;br/&gt;</string></value>'
              . '</member></struct></value></member></struct></value>';
 
@@ -480,7 +499,7 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = ['foo' => 0, 'bar' => 1];
-        $xml = '<value><struct>'
+        $xml    = '<value><struct>'
              . '<member><name>foo</name><value><int>0</int></value></member>'
              . '<member><name>foo</name><bar/></member>'
              . '<member><name>bar</name><value><int>1</int></value></member>'
@@ -504,7 +523,7 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = ['foo' => 0, 'bar' => 1];
-        $xml = '<value><struct>'
+        $xml    = '<value><struct>'
              . '<member><name>foo</name><value><int>0</int></value></member>'
              . '<member><value><string>foo</string></value></member>'
              . '<member><name>bar</name><value><int>1</int></value></member>'
@@ -529,9 +548,9 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = ['&nbsp;' => 0];
-        $xml = '<value><struct><member><name>&amp;nbsp;</name><value><int>0</int>'
+        $xml    = '<value><struct><member><name>&amp;nbsp;</name><value><int>0</int>'
              . '</value></member></struct></value>';
-        $val = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
+        $val    = AbstractValue::getXmlRpcValue($xml, AbstractValue::XML_STRING);
         $this->assertXmlRpcType('struct', $val);
         $this->assertSame($native, $val->getValue());
         $this->assertSame($this->wrapXml($xml), $val->saveXml());
@@ -545,7 +564,7 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = ['foo' => ''];
-        $xml = '<value><struct><member><name>foo</name>'
+        $xml    = '<value><struct><member><name>foo</name>'
              . '<value><string/></value></member></struct></value>';
 
         $val = AbstractValue::getXmlRpcValue(
@@ -565,9 +584,9 @@ class ValueTest extends TestCase
     public function testMarshallingStructWithMultibyteValueFromXmlRpcRetainsMultibyteValue(Generator $generator)
     {
         AbstractValue::setGenerator($generator);
-        $native = ['foo' => 'ß'];
+        $native  = ['foo' => 'ß'];
         $xmlDecl = '<?xml version="1.0" encoding="UTF-8"?>';
-        $xml = '<value><struct><member><name>foo</name><value><string>ß</string></value></member></struct></value>';
+        $xml     = '<value><struct><member><name>foo</name><value><string>ß</string></value></member></struct></value>';
 
         $val = AbstractValue::getXmlRpcValue(
             $xmlDecl . $xml,
@@ -589,7 +608,7 @@ class ValueTest extends TestCase
     public function testMarshalDateTimeFromNativeString()
     {
         $native = '1997-07-16T19:20+01:00';
-        $val = AbstractValue::getXmlRpcValue(
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_DATETIME
         );
@@ -603,7 +622,7 @@ class ValueTest extends TestCase
     public function testMarshalDateTimeFromNativeStringProducesIsoOutput()
     {
         $native = '1997-07-16T19:20+01:00';
-        $val = AbstractValue::getXmlRpcValue(
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_DATETIME
         );
@@ -625,7 +644,7 @@ class ValueTest extends TestCase
     public function testMarshalDateTimeFromNativeInteger()
     {
         $native = strtotime('1997-07-16T19:20+01:00');
-        $val = AbstractValue::getXmlRpcValue(
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_DATETIME
         );
@@ -639,8 +658,8 @@ class ValueTest extends TestCase
      */
     public function testMarshalDateTimeBeyondUnixEpochFromNativeStringPassedToConstructor()
     {
-        $native = '2040-01-01T00:00:00';
-        $value  = new Value\DateTime($native);
+        $native   = '2040-01-01T00:00:00';
+        $value    = new Value\DateTime($native);
         $expected = new DateTime($native);
         $this->assertSame($expected->format($this->xmlRpcDateFormat), $value->getValue());
     }
@@ -652,7 +671,7 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $iso8601 = '1997-07-16T19:20+01:00';
-        $xml = "<value><dateTime.iso8601>$iso8601</dateTime.iso8601></value>";
+        $xml     = "<value><dateTime.iso8601>$iso8601</dateTime.iso8601></value>";
 
         $val = AbstractValue::getXmlRpcValue(
             $xml,
@@ -674,9 +693,9 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $dateString = '20390418T13:14:15';
-        $date = new DateTime($dateString);
+        $date       = new DateTime($dateString);
         $dateString = '20390418T13:14:15';
-        $xml = "<value><dateTime.iso8601>$dateString</dateTime.iso8601></value>";
+        $xml        = "<value><dateTime.iso8601>$dateString</dateTime.iso8601></value>";
 
         $val = AbstractValue::getXmlRpcValue($date, AbstractValue::XMLRPC_TYPE_DATETIME);
         $this->assertXmlRpcType('dateTime', $val);
@@ -693,8 +712,8 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $dateString = '20390418T13:14:15';
-        $date = new \DateTime($dateString);
-        $xml = "<value><dateTime.iso8601>$dateString</dateTime.iso8601></value>";
+        $date       = new DateTime($dateString);
+        $xml        = "<value><dateTime.iso8601>$dateString</dateTime.iso8601></value>";
 
         $val = AbstractValue::getXmlRpcValue($date, AbstractValue::AUTO_DETECT_TYPE);
         $this->assertXmlRpcType('dateTime', $val);
@@ -709,8 +728,8 @@ class ValueTest extends TestCase
     public function testGetValueDatetime()
     {
         $expectedValue = '20100101T00:00:00';
-        $phpDatetime     = new DateTime('20100101T00:00:00');
-        $phpDateNative   = '20100101T00:00:00';
+        $phpDatetime   = new DateTime('20100101T00:00:00');
+        $phpDateNative = '20100101T00:00:00';
 
         $xmlRpcValueDateTime = new Value\DateTime($phpDatetime);
         $this->assertEquals($expectedValue, $xmlRpcValueDateTime->getValue());
@@ -724,7 +743,7 @@ class ValueTest extends TestCase
     public function testMarshalBase64FromString()
     {
         $native = 'foo';
-        $val = AbstractValue::getXmlRpcValue(
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_BASE64
         );
@@ -740,7 +759,7 @@ class ValueTest extends TestCase
     {
         AbstractValue::setGenerator($generator);
         $native = 'foo';
-        $xml = '<value><base64>' .base64_encode($native). '</base64></value>';
+        $xml    = '<value><base64>' . base64_encode($native) . '</base64></value>';
 
         $val = AbstractValue::getXmlRpcValue(
             $xml,
@@ -756,13 +775,13 @@ class ValueTest extends TestCase
     public function testXmlRpcValueBase64GeneratedXmlContainsBase64EncodedText()
     {
         $native = 'foo';
-        $val = AbstractValue::getXmlRpcValue(
+        $val    = AbstractValue::getXmlRpcValue(
             $native,
             AbstractValue::XMLRPC_TYPE_BASE64
         );
 
         $this->assertXmlRpcType('base64', $val);
-        $xml = $val->saveXml();
+        $xml     = $val->saveXml();
         $encoded = base64_encode($native);
         $this->assertStringContainsString($encoded, $xml);
     }
@@ -775,7 +794,7 @@ class ValueTest extends TestCase
         $o = new TestAsset\SerializableTestClass();
         $o->setProperty('foobar');
         $serialized = serialize($o);
-        $val = AbstractValue::getXmlRpcValue(
+        $val        = AbstractValue::getXmlRpcValue(
             $serialized,
             AbstractValue::XMLRPC_TYPE_BASE64
         );
@@ -813,17 +832,16 @@ class ValueTest extends TestCase
         $this->assertSame($xmlRpcValue, AbstractValue::getXmlRpcValue($xmlRpcValue));
     }
 
-
     public function testGetXmlRpcTypeByValue()
     {
         $this->assertSame(
             AbstractValue::XMLRPC_TYPE_NIL,
-            AbstractValue::getXmlRpcTypeByValue(new Value\Nil)
+            AbstractValue::getXmlRpcTypeByValue(new Value\Nil())
         );
 
         $this->assertEquals(
             AbstractValue::XMLRPC_TYPE_DATETIME,
-            AbstractValue::getXmlRpcTypeByValue(new DateTime)
+            AbstractValue::getXmlRpcTypeByValue(new DateTime())
         );
 
         $this->assertEquals(
@@ -831,7 +849,7 @@ class ValueTest extends TestCase
             AbstractValue::getXmlRpcTypeByValue(['foo' => 'bar'])
         );
 
-        $object = new stdClass;
+        $object      = new stdClass();
         $object->foo = 'bar';
 
         $this->assertEquals(
@@ -841,7 +859,7 @@ class ValueTest extends TestCase
 
         $this->assertEquals(
             AbstractValue::XMLRPC_TYPE_ARRAY,
-            AbstractValue::getXmlRpcTypeByValue(new stdClass)
+            AbstractValue::getXmlRpcTypeByValue(new stdClass())
         );
 
         $this->assertEquals(

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,14 +1,9 @@
 <?php
 
 /**
- * @see       https://github.com/laminas/laminas-xmlrpc for the canonical source repository
- * @copyright https://github.com/laminas/laminas-xmlrpc/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-xmlrpc/blob/master/LICENSE.md New BSD License
- */
-
-/**
  * @todo This file may be removed once we drop support for PHP 5.
  */
+
 if (! class_exists(PHPUnit\Framework\ExpectationFailedException::class)) {
     class_alias(
         PHPUnit_Framework_ExpectationFailedException::class,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

This PR updates the `laminas-coding-standard` to version `2.2.1` and provides necessary code changes.

For the upgrade to `2.3.0`, "only" strict type declaration is required. I am not sure, if that would break parts of the component.