### PR TITLE
[Php 7.4] Apply Up to Php 7.4 syntax

### DIFF
--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -172,7 +172,7 @@ abstract class AbstractValue
     {
         if (! $this->xml) {
             $this->generateXml();
-            $this->xml = (string) $this->getGenerator();
+            $this->xml = (string) static::getGenerator();
         }
         return $this->xml;
     }
@@ -498,6 +498,6 @@ abstract class AbstractValue
      */
     protected function setXML($xml)
     {
-        $this->xml = $this->getGenerator()->stripDeclaration($xml);
+        $this->xml = static::getGenerator()->stripDeclaration($xml);
     }
 }

--- a/src/Client/ServerIntrospection.php
+++ b/src/Client/ServerIntrospection.php
@@ -3,7 +3,6 @@
 namespace Laminas\XmlRpc\Client;
 
 use Laminas\XmlRpc\Client as XMLRPCClient;
-use Laminas\XmlRpc\Client\ServerProxy;
 
 use function count;
 use function gettype;
@@ -14,8 +13,7 @@ use function is_array;
  */
 class ServerIntrospection
 {
-    /** @var ServerProxy */
-    private $system;
+    private ServerProxy $system;
 
     public function __construct(XMLRPCClient $client)
     {

--- a/src/Client/ServerProxy.php
+++ b/src/Client/ServerProxy.php
@@ -13,14 +13,12 @@ use function ltrim;
  */
 class ServerProxy
 {
-    /** @var XMLRPCClient */
-    private $client;
+    private XMLRPCClient $client;
 
-    /** @var string */
-    private $namespace = '';
+    private string $namespace = '';
 
     /** @var array of \Laminas\XmlRpc\Client\ServerProxy */
-    private $cache = [];
+    private array $cache = [];
 
     /**
      * @param string             $namespace

--- a/src/Server.php
+++ b/src/Server.php
@@ -2,6 +2,7 @@
 
 namespace Laminas\XmlRpc;
 
+use DateTime;
 use Exception;
 use Laminas\Server\AbstractServer;
 use Laminas\Server\Definition;
@@ -112,7 +113,7 @@ class Server extends AbstractServer
         'dateTime.iso8601' => 'dateTime.iso8601',
         'date'             => 'dateTime.iso8601',
         'time'             => 'dateTime.iso8601',
-        'DateTime'         => 'dateTime.iso8601',
+        DateTime::class    => 'dateTime.iso8601',
         'array'            => 'array',
         'struct'           => 'struct',
         'null'             => 'nil',

--- a/src/Value/AbstractScalar.php
+++ b/src/Value/AbstractScalar.php
@@ -13,7 +13,7 @@ abstract class AbstractScalar extends AbstractValue
      */
     protected function generate()
     {
-        $generator = $this->getGenerator();
+        $generator = static::getGenerator();
 
         $generator
             ->openElement('value')

--- a/src/Value/ArrayValue.php
+++ b/src/Value/ArrayValue.php
@@ -24,7 +24,7 @@ class ArrayValue extends AbstractCollection
      */
     protected function generate()
     {
-        $generator = $this->getGenerator();
+        $generator = static::getGenerator();
         $generator
             ->openElement('value')
             ->openElement('array')

--- a/src/Value/Struct.php
+++ b/src/Value/Struct.php
@@ -24,7 +24,7 @@ class Struct extends AbstractCollection
      */
     protected function generate()
     {
-        $generator = $this->getGenerator();
+        $generator = static::getGenerator();
         $generator
             ->openElement('value')
             ->openElement('struct');

--- a/test/Server/TestAsset/Observer.php
+++ b/test/Server/TestAsset/Observer.php
@@ -6,8 +6,7 @@ use Laminas\XmlRpc\Server\Fault;
 
 class Observer
 {
-    /** @var self|null */
-    private static $instance;
+    private static ?Observer $instance = null;
 
     /** @var array */
     public $observed = [];

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -663,14 +663,14 @@ class ServerTest extends TestCase
     {
         $this->expectException(ExceptionInterface::class);
         $this->expectExceptionMessage('Invalid request class');
-        $this->server->setRequest('stdClass');
+        $this->server->setRequest(stdClass::class);
     }
 
     public function testPassingInvalidResponseClassThrowsException()
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid response class');
-        $this->server->setResponseClass('stdClass');
+        $this->server->setResponseClass(stdClass::class);
     }
 
     public function testCreatingFaultWithEmptyMessageResultsInUnknownError()


### PR DESCRIPTION
Signed-off-by: Abdul Malik Ikhsan <samsonasik@gmail.com>

<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Since this component require php 7.4, we can apply syntax up to php 7.4 syntax support, with typed property (only for private modifier to keep BC).

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
