### PR TITLE
Allow specifying `LIBXML_` flags when sending/receiving/loading requests/responses

### DIFF
--- a/docs/book/client.md
+++ b/docs/book/client.md
@@ -324,3 +324,24 @@ The `setHttpClient()` is particularly useful for unit testing. When combined
 with `Laminas\Http\Client\Adapter\Test`, remote services can be mocked out for
 testing. See the unit tests for `Laminas\XmlRpc\Client` for examples of how to do
 this.
+
+## Providing libxml Options
+
+The various XML extensions to PHP are linked to libxml, and many allow providing libxml options for purposes of shaping how libxml parses and/or produces XML.
+A full [list of libxml constants is available in the PHP documentation](https://www.php.net/manual/en/libxml.constants.php).
+
+When using the XML-RPC client, you may pass these as the third argument to the client's `doRequest()` method:
+
+```php
+// With a response:
+$client->doRequest($request, $response, LIBXML_PARSEHUGE)
+
+// Without passing a response:
+$client->doRequest($request, null, LIBXML_PARSEHUGE)
+```
+
+Per standard usage of these constants, you can provide multiple options by using the `|` operator:
+
+```php
+$client->doRequest($request, $response, LIBXML_PARSEHUGE | LIBXML_BIGLINES)
+```

--- a/docs/book/server.md
+++ b/docs/book/server.md
@@ -534,3 +534,28 @@ $server = new XmlRpc\Server();
 >
 > Optimization makes sense for the client side too. Just select the alternate
 > XML generator before doing any work with `Laminas\XmlRpc\Client`.
+
+## Providing libxml Options
+
+The various XML extensions to PHP are linked to libxml, and many allow providing libxml options for purposes of shaping how libxml parses and/or produces XML.
+A full [list of libxml constants is available in the PHP documentation](https://www.php.net/manual/en/libxml.constants.php).
+
+When providing an XML-RPC server, you may pass these when you call the request's `loadXml()` method:
+
+```php
+use Laminas\XmlRpc\Request;
+use Laminas\XmlRpc\Server;
+
+$server = new Server();
+// setup server by adding classes and functions...
+
+$request = new Request();
+$request->loadXml(file_get_contents('php://input'), LIBXML_PARSEHUGE);
+echo $server->handle($request);
+```
+
+Per standard usage of these constants, you can provide multiple options by using the `|` operator:
+
+```php
+$request->loadXml(file_get_contents('php://input'), LIBXML_PARSEHUGE | LIBXML_BIGLINES);
+```

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -197,8 +197,13 @@ abstract class AbstractValue
      *
      * By default the value type is autodetected according to it's PHP type
      *
+     * You may optionally pass a bitmask of LIBXML options via the
+     * $libXmlOptions parameter; as an example, you might use LIBXML_PARSEHUGE.
+     * See https://www.php.net/manual/en/libxml.constants.php for a full list.
+     *
      * @param  mixed $value
      * @param  Laminas\XmlRpc\Value::constant $type
+     * @param int $libXmlOptions Bitmask of LIBXML options to use for XML * operations
      * @throws ValueException
      * @return AbstractValue
      */

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -202,7 +202,7 @@ abstract class AbstractValue
      * @throws ValueException
      * @return AbstractValue
      */
-    public static function getXmlRpcValue($value, $type = self::AUTO_DETECT_TYPE)
+    public static function getXmlRpcValue($value, $type = self::AUTO_DETECT_TYPE, int $libXmlOptions = 0)
     {
         switch ($type) {
             case self::AUTO_DETECT_TYPE:
@@ -211,7 +211,7 @@ abstract class AbstractValue
 
             case self::XML_STRING:
                 // Parse the XML string given in $value and get the XML-RPC value in it
-                return static::xmlStringToNativeXmlRpc($value);
+                return static::xmlStringToNativeXmlRpc($value, $libXmlOptions);
 
             case self::XMLRPC_TYPE_I4:
                 // fall through to the next case
@@ -347,9 +347,9 @@ abstract class AbstractValue
      * @return AbstractValue
      * @static
      */
-    protected static function xmlStringToNativeXmlRpc($xml)
+    protected static function xmlStringToNativeXmlRpc($xml, int $libXmlOptions = 0)
     {
-        static::createSimpleXMLElement($xml);
+        static::createSimpleXMLElement($xml, $libXmlOptions);
 
         static::extractTypeAndValue($xml, $type, $value);
 
@@ -408,7 +408,7 @@ abstract class AbstractValue
                 // Parse all the elements of the array from the XML string
                 // (simple xml element) to Value objects
                 foreach ($data->value as $element) {
-                    $values[] = static::xmlStringToNativeXmlRpc($element);
+                    $values[] = static::xmlStringToNativeXmlRpc($element, $libXmlOptions);
                 }
                 $xmlrpcValue = new Value\ArrayValue($values);
                 break;
@@ -422,7 +422,7 @@ abstract class AbstractValue
                     if (! isset($member->value) || ! isset($member->name)) {
                         continue;
                     }
-                    $values[(string) $member->name] = static::xmlStringToNativeXmlRpc($member->value);
+                    $values[(string) $member->name] = static::xmlStringToNativeXmlRpc($member->value, $libXmlOptions);
                 }
                 $xmlrpcValue = new Value\Struct($values);
                 break;
@@ -439,14 +439,14 @@ abstract class AbstractValue
     /**
      * @param SimpleXMLElement|string $xml
      */
-    protected static function createSimpleXMLElement(&$xml)
+    protected static function createSimpleXMLElement(&$xml, int $libXmlOptions = 0)
     {
         if ($xml instanceof SimpleXMLElement) {
             return;
         }
 
         try {
-            $xml = new SimpleXMLElement($xml);
+            $xml = new SimpleXMLElement($xml, $libXmlOptions);
         } catch (Exception $e) {
             // The given string is not a valid XML
             throw new ValueException(

--- a/src/Client.php
+++ b/src/Client.php
@@ -199,8 +199,13 @@ class Client implements ServerClient
     /**
      * Perform an XML-RPC request and return a response.
      *
+     * You may optionally pass a bitmask of LIBXML options via the
+     * $libXmlOptions parameter; as an example, you might use LIBXML_PARSEHUGE.
+     * See https://www.php.net/manual/en/libxml.constants.php for a full list.
+     *
      * @param Request $request
      * @param null|Response $response
+     * @param int $libXmlOptions Bitmask of LIBXML options to use for XML * operations
      * @throws InvalidArgumentException
      * @throws RuntimeException
      * @throws HttpException

--- a/src/Client.php
+++ b/src/Client.php
@@ -207,7 +207,7 @@ class Client implements ServerClient
      * @throws ValueException
      * @return void
      */
-    public function doRequest($request, $response = null)
+    public function doRequest($request, $response = null, int $libXmlOptions = 0)
     {
         $this->lastRequest = $request;
 
@@ -258,7 +258,7 @@ class Client implements ServerClient
         }
 
         $this->lastResponse = $response;
-        $this->lastResponse->loadXml(trim($httpResponse->getBody()));
+        $this->lastResponse->loadXml(trim($httpResponse->getBody()), $libXmlOptions);
     }
 
     /**

--- a/src/Request.php
+++ b/src/Request.php
@@ -286,7 +286,12 @@ class Request
     /**
      * Load XML and parse into request components
      *
+     * You may optionally pass a bitmask of LIBXML options via the
+     * $libXmlOptions parameter; as an example, you might use LIBXML_PARSEHUGE.
+     * See https://www.php.net/manual/en/libxml.constants.php for a full list.
+     *
      * @param string $request
+     * @param int $libXmlOptions Bitmask of LIBXML options to use for XML * operations
      * @throws ValueException If invalid XML.
      * @return bool True on success, false if an error occurred.
      */

--- a/src/Request.php
+++ b/src/Request.php
@@ -290,7 +290,7 @@ class Request
      * @throws ValueException If invalid XML.
      * @return bool True on success, false if an error occurred.
      */
-    public function loadXml($request)
+    public function loadXml($request, int $libXmlOptions = 0)
     {
         if (! is_string($request)) {
             $this->fault = new Fault(635);
@@ -305,7 +305,7 @@ class Request
 
         try {
             $dom = new DOMDocument();
-            $dom->loadXML($request);
+            $dom->loadXML($request, $libXmlOptions);
             foreach ($dom->childNodes as $child) {
                 if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {
                     throw new ValueException(

--- a/src/Response.php
+++ b/src/Response.php
@@ -142,7 +142,12 @@ class Response
      * Attempts to load a response from an XMLRPC response, autodetecting if it
      * is a fault response.
      *
+     * You may optionally pass a bitmask of LIBXML options via the
+     * $libXmlOptions parameter; as an example, you might use LIBXML_PARSEHUGE.
+     * See https://www.php.net/manual/en/libxml.constants.php for a full list.
+     *
      * @param string $response
+     * @param int $libXmlOptions Bitmask of LIBXML options to use for XML * operations
      * @throws Exception\ValueException If invalid XML.
      * @return bool True if a valid XMLRPC response, false if a fault
      * response or invalid input

--- a/src/Response.php
+++ b/src/Response.php
@@ -147,7 +147,7 @@ class Response
      * @return bool True if a valid XMLRPC response, false if a fault
      * response or invalid input
      */
-    public function loadXml($response)
+    public function loadXml($response, int $libXmlOptions = 0)
     {
         if (! is_string($response)) {
             $this->fault = new Fault(650);
@@ -156,7 +156,7 @@ class Response
         }
 
         try {
-            $xml = XmlSecurity::scan($response);
+            $xml = XmlSecurity::scan($response, null, $libXmlOptions);
         } catch (RuntimeException $e) {
             $this->fault = new Fault(651);
             $this->fault->setEncoding($this->getEncoding());
@@ -183,7 +183,7 @@ class Response
                 throw new Exception\ValueException('Missing XML-RPC value in XML');
             }
             $valueXml = $xml->params->param->value->asXML();
-            $value    = AbstractValue::getXmlRpcValue($valueXml, AbstractValue::XML_STRING);
+            $value    = AbstractValue::getXmlRpcValue($valueXml, AbstractValue::XML_STRING, $libXmlOptions);
         } catch (Exception\ValueException $e) {
             $this->fault = new Fault(653);
             $this->fault->setEncoding($this->getEncoding());


### PR DESCRIPTION
Supersedes #4.

Rationale: no member properties or state required.

## Client

Easy.

```php
$client->doRequest($request, null, LIBXML_PARSEHUGE);
```

## Server

Thought about changing `Http` and `Stdin` classes, decided not to. Let's leave those alone. Decided developer has to instantiate Request and then call `loadXml()`.

```php
$request = new \Laminas\XmlRpc\Request();
$request->loadXml(file_get_contents('php://input'), LIBXML_PARSEHUGE);
echo $server->handle($request);
```