### PR TITLE
Bump phpunit to 10.4, update configs. Update psalm. Fix broken tests

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Build Docs
         uses: laminas/documentation-theme/github-actions/docs@master
         env:
-          "DOCS_DEPLOY_KEY": ${{ secrets.DOCS_DEPLOY_KEY }}
+          "DEPLOY_TOKEN": ${{ secrets.GITHUB_TOKEN }}
           "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.phpunit.result.cache
+/.phpunit.cache
 /docs/html/
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phpunit.cache
+/.psalm-cache
 /docs/html/
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # laminas-xmlrpc
 
-[![Build Status](https://github.com/laminas/laminas-xmlrpc/workflows/Continuous%20Integration/badge.svg)](https://github.com/laminas/laminas-xmlrpc/actions?query=workflow%3A"Continuous+Integration")
+[![Build Status](https://github.com/laminas/laminas-xmlrpc/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/laminas/laminas-xmlrpc/actions/workflows/continuous-integration.yml)
+[![type-coverage](https://shepherd.dev/github/laminas/laminas-xmlrpc/coverage.svg)](https://shepherd.dev/github/laminas/laminas-xmlrpc)
+[![Psalm level](https://shepherd.dev/github/laminas/laminas-xmlrpc/level.svg)](https://shepherd.dev/github/laminas/laminas-xmlrpc)
 
 > ## 🇷🇺 Русским гражданам
 >

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require": {
         "php": "~8.1.0 || ~8.2.0",
+        "ext-simplexml": "*",
         "laminas/laminas-code": "^4.4",
         "laminas/laminas-http": "^2.15",
         "laminas/laminas-math": "^3.4.0",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "laminas/laminas-coding-standard": "~2.5.0",
         "phpunit/phpunit": "^10.4",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.4"
+        "vimeo/psalm": "^5.16"
     },
     "suggest": {
         "laminas/laminas-cache": "To support Laminas\\XmlRpc\\Server\\Cache usage"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
-        "phpunit/phpunit": "^10.0",
+        "phpunit/phpunit": "^10.4",
         "psalm/plugin-phpunit": "^0.18.4",
         "vimeo/psalm": "^5.4"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,33 +4,33 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5217c30afb2d4b7c5de339646967c641",
+    "content-hash": "e7ec69d697bed2d8909ba6da903e7835",
     "packages": [
         {
             "name": "laminas/laminas-code",
-            "version": "4.9.0",
+            "version": "4.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-code.git",
-                "reference": "c1706ecde17f87ae8bab169c4b88006c9253d3a5"
+                "reference": "7353d4099ad5388e84737dd16994316a04f48dbf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/c1706ecde17f87ae8bab169c4b88006c9253d3a5",
-                "reference": "c1706ecde17f87ae8bab169c4b88006c9253d3a5",
+                "url": "https://api.github.com/repos/laminas/laminas-code/zipball/7353d4099ad5388e84737dd16994316a04f48dbf",
+                "reference": "7353d4099ad5388e84737dd16994316a04f48dbf",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^2.0.0",
+                "doctrine/annotations": "^2.0.1",
                 "ext-phar": "*",
-                "laminas/laminas-coding-standard": "^2.3.0",
-                "laminas/laminas-stdlib": "^3.6.1",
-                "phpunit/phpunit": "^10.0.9",
+                "laminas/laminas-coding-standard": "^2.5.0",
+                "laminas/laminas-stdlib": "^3.17.0",
+                "phpunit/phpunit": "^10.3.3",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.7.1"
+                "vimeo/psalm": "^5.15.0"
             },
             "suggest": {
                 "doctrine/annotations": "Doctrine\\Common\\Annotations >=1.0 for annotation features",
@@ -67,37 +67,37 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-03-04T10:09:37+00:00"
+            "time": "2023-10-18T10:00:55+00:00"
         },
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.12.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "ee7a4c37bf3d0e8c03635d5bddb5bb3184ead490"
+                "reference": "af459883f4018d0f8a0c69c7a209daef3bf973ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/ee7a4c37bf3d0e8c03635d5bddb5bb3184ead490",
-                "reference": "ee7a4c37bf3d0e8c03635d5bddb5bb3184ead490",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/af459883f4018d0f8a0c69c7a209daef3bf973ba",
+                "reference": "af459883f4018d0f8a0c69c7a209daef3bf973ba",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
                 "ext-mbstring": "*",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "conflict": {
                 "zendframework/zend-escaper": "*"
             },
             "require-dev": {
-                "infection/infection": "^0.26.6",
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "infection/infection": "^0.27.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "maglnet/composer-require-checker": "^3.8.0",
-                "phpunit/phpunit": "^9.5.18",
-                "psalm/plugin-phpunit": "^0.17.0",
-                "vimeo/psalm": "^4.22.0"
+                "phpunit/phpunit": "^9.6.7",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.9"
             },
             "type": "library",
             "autoload": {
@@ -129,7 +129,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-10T10:11:09+00:00"
+            "time": "2023-10-10T08:35:13+00:00"
         },
         {
             "name": "laminas/laminas-http",
@@ -198,20 +198,20 @@
         },
         {
             "name": "laminas/laminas-loader",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-loader.git",
-                "reference": "51ed9c3fa42d1098a9997571730c0cbf42d078d3"
+                "reference": "e6fe952304ef40ce45cd814751ab35d42afdad12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/51ed9c3fa42d1098a9997571730c0cbf42d078d3",
-                "reference": "51ed9c3fa42d1098a9997571730c0cbf42d078d3",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/e6fe952304ef40ce45cd814751ab35d42afdad12",
+                "reference": "e6fe952304ef40ce45cd814751ab35d42afdad12",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "conflict": {
                 "zendframework/zend-loader": "*"
@@ -250,25 +250,25 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-16T12:50:49+00:00"
+            "time": "2023-10-18T09:58:51+00:00"
         },
         {
             "name": "laminas/laminas-math",
-            "version": "3.6.0",
+            "version": "3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-math.git",
-                "reference": "5770fc632a3614f5526632a8b70f41b65130460e"
+                "reference": "3e90445828fd64308de2a600b48c3df051b3b17a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-math/zipball/5770fc632a3614f5526632a8b70f41b65130460e",
-                "reference": "5770fc632a3614f5526632a8b70f41b65130460e",
+                "url": "https://api.github.com/repos/laminas/laminas-math/zipball/3e90445828fd64308de2a600b48c3df051b3b17a",
+                "reference": "3e90445828fd64308de2a600b48c3df051b3b17a",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "conflict": {
                 "zendframework/zend-math": "*"
@@ -317,35 +317,35 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-10-16T14:22:28+00:00"
+            "time": "2023-10-18T09:53:37+00:00"
         },
         {
             "name": "laminas/laminas-server",
-            "version": "2.15.0",
+            "version": "2.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-server.git",
-                "reference": "7f4862913ab95ea5decd08e6c3717edbb398fde8"
+                "reference": "659a56f69fc27e787385f3d713c81bc1eae01eb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-server/zipball/7f4862913ab95ea5decd08e6c3717edbb398fde8",
-                "reference": "7f4862913ab95ea5decd08e6c3717edbb398fde8",
+                "url": "https://api.github.com/repos/laminas/laminas-server/zipball/659a56f69fc27e787385f3d713c81bc1eae01eb0",
+                "reference": "659a56f69fc27e787385f3d713c81bc1eae01eb0",
                 "shasum": ""
             },
             "require": {
                 "laminas/laminas-code": "^4.7.1",
                 "laminas/laminas-stdlib": "^3.3.1",
                 "laminas/laminas-zendframework-bridge": "^1.2.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "replace": {
                 "zendframework/zend-server": "^2.8.1"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-coding-standard": "~2.5.0",
                 "phpunit/phpunit": "^9.5.5",
-                "psalm/plugin-phpunit": "^0.15.1",
+                "psalm/plugin-phpunit": "^0.18.0",
                 "vimeo/psalm": "^4.6.4"
             },
             "type": "library",
@@ -378,7 +378,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-27T17:14:59+00:00"
+            "time": "2023-11-14T09:53:27+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -472,30 +472,30 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.16.1",
+            "version": "3.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17"
+                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
-                "reference": "f4f773641807c7ccee59b758bfe4ac4ba33ecb17",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
+                "reference": "e85b29076c6216e7fc98e72b42dbe1bbc3b95ecf",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "conflict": {
                 "zendframework/zend-stdlib": "*"
             },
             "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "phpbench/phpbench": "^1.2.7",
-                "phpunit/phpunit": "^9.5.26",
-                "psalm/plugin-phpunit": "^0.18.0",
-                "vimeo/psalm": "^5.0.0"
+                "laminas/laminas-coding-standard": "^2.5",
+                "phpbench/phpbench": "^1.2.14",
+                "phpunit/phpunit": "^10.3.3",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.15.0"
             },
             "type": "library",
             "autoload": {
@@ -527,7 +527,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-03T18:48:01+00:00"
+            "time": "2023-09-19T10:15:21+00:00"
         },
         {
             "name": "laminas/laminas-uri",
@@ -674,22 +674,22 @@
         },
         {
             "name": "laminas/laminas-xml",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-xml.git",
-                "reference": "30a4da5a003971de8f54e6810e742fe375e5d5d3"
+                "reference": "c35aab57d1d0a970b53965046d535b88c3dc8bea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-xml/zipball/30a4da5a003971de8f54e6810e742fe375e5d5d3",
-                "reference": "30a4da5a003971de8f54e6810e742fe375e5d5d3",
+                "url": "https://api.github.com/repos/laminas/laminas-xml/zipball/c35aab57d1d0a970b53965046d535b88c3dc8bea",
+                "reference": "c35aab57d1d0a970b53965046d535b88c3dc8bea",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-simplexml": "*",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "conflict": {
                 "zendframework/zendxml": "*"
@@ -730,30 +730,30 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-11-16T00:17:18+00:00"
+            "time": "2023-11-23T10:03:52+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "5ef52e26392777a26dbb8f20fe24f91b406459f6"
+                "reference": "eb0d96c708b92177a92bc2239543d3ed523452c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/5ef52e26392777a26dbb8f20fe24f91b406459f6",
-                "reference": "5ef52e26392777a26dbb8f20fe24f91b406459f6",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/eb0d96c708b92177a92bc2239543d3ed523452c6",
+                "reference": "eb0d96c708b92177a92bc2239543d3ed523452c6",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.26",
+                "phpunit/phpunit": "^10.4",
                 "psalm/plugin-phpunit": "^0.18.0",
                 "squizlabs/php_codesniffer": "^3.7.1",
-                "vimeo/psalm": "^4.29.0"
+                "vimeo/psalm": "^5.16.0"
             },
             "type": "library",
             "extra": {
@@ -792,7 +792,8 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-12-12T11:44:10+00:00"
+            "abandoned": true,
+            "time": "2023-11-24T13:56:19+00:00"
         },
         {
             "name": "psr/container",
@@ -849,25 +850,25 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.0.1",
+            "version": "1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.1.x-dev"
                 }
             },
             "autoload": {
@@ -896,9 +897,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/master"
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
             },
-            "time": "2016-08-06T14:39:51+00:00"
+            "time": "2023-04-04T09:50:52+00:00"
         }
     ],
     "packages-dev": [
@@ -1143,16 +1144,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2"
+                "reference": "00104306927c7a0919b4ced2aaa6782c1e61a3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
-                "reference": "4bff79ddd77851fe3cdd11616ed3f92841ba5bd2",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/00104306927c7a0919b4ced2aaa6782c1e61a3c9",
+                "reference": "00104306927c7a0919b4ced2aaa6782c1e61a3c9",
                 "shasum": ""
             },
             "require": {
@@ -1194,7 +1195,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.0"
+                "source": "https://github.com/composer/pcre/tree/3.1.1"
             },
             "funding": [
                 {
@@ -1210,20 +1211,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-17T09:50:14+00:00"
+            "time": "2023-10-11T07:11:09+00:00"
         },
         {
             "name": "composer/semver",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
                 "shasum": ""
             },
             "require": {
@@ -1273,9 +1274,9 @@
                 "versioning"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.2"
+                "source": "https://github.com/composer/semver/tree/3.4.0"
             },
             "funding": [
                 {
@@ -1291,7 +1292,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T19:23:25+00:00"
+            "time": "2023-08-31T09:50:34+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1691,16 +1692,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -1738,7 +1739,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -1746,20 +1747,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.1.0",
+            "version": "v4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f"
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
-                "reference": "cfa81ea1d35294d64adb9c68aa4cb9e92400e53f",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/f60565f8c0566a31acf06884cdaa591867ecc956",
+                "reference": "f60565f8c0566a31acf06884cdaa591867ecc956",
                 "shasum": ""
             },
             "require": {
@@ -1795,22 +1796,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.1.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v4.2.0"
             },
-            "time": "2022-12-08T20:46:14+00:00"
+            "time": "2023-04-09T17:37:40+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.3",
+            "version": "v4.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039"
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/570e980a201d8ed0236b0a62ddf2c9cbb2034039",
-                "reference": "570e980a201d8ed0236b0a62ddf2c9cbb2034039",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
+                "reference": "a6303e50c90c355c7eeee2c4a8b27fe8dc8fef1d",
                 "shasum": ""
             },
             "require": {
@@ -1851,9 +1852,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.3"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.17.1"
             },
-            "time": "2023-01-16T22:05:37+00:00"
+            "time": "2023-08-13T19:53:39+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -2177,16 +2178,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.0.1",
+            "version": "10.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "b9c21a93dd8c8eed79879374884ee733259475cc"
+                "reference": "a56a9ab2f680246adcf3db43f38ddf1765774735"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/b9c21a93dd8c8eed79879374884ee733259475cc",
-                "reference": "b9c21a93dd8c8eed79879374884ee733259475cc",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a56a9ab2f680246adcf3db43f38ddf1765774735",
+                "reference": "a56a9ab2f680246adcf3db43f38ddf1765774735",
                 "shasum": ""
             },
             "require": {
@@ -2205,16 +2206,16 @@
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.0-dev"
+                    "dev-main": "10.1-dev"
                 }
             },
             "autoload": {
@@ -2242,7 +2243,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.0.1"
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.9"
             },
             "funding": [
                 {
@@ -2250,20 +2252,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-25T05:35:03+00:00"
+            "time": "2023-11-23T12:23:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.0.1",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
-                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
@@ -2302,7 +2304,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
             },
             "funding": [
                 {
@@ -2310,7 +2313,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-10T16:53:14+00:00"
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -2377,16 +2380,16 @@
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
                 "shasum": ""
             },
             "require": {
@@ -2424,7 +2427,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
             },
             "funding": [
                 {
@@ -2432,7 +2436,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:46+00:00"
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -2495,16 +2499,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.0.14",
+            "version": "10.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "7065dbebcb0f66cf16a45fc9cfc28c2351e06169"
+                "reference": "cacd8b9dd224efa8eb28beb69004126c7ca1a1a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7065dbebcb0f66cf16a45fc9cfc28c2351e06169",
-                "reference": "7065dbebcb0f66cf16a45fc9cfc28c2351e06169",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/cacd8b9dd224efa8eb28beb69004126c7ca1a1a1",
+                "reference": "cacd8b9dd224efa8eb28beb69004126c7ca1a1a1",
                 "shasum": ""
             },
             "require": {
@@ -2518,7 +2522,7 @@
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.0",
+                "phpunit/php-code-coverage": "^10.1.5",
                 "phpunit/php-file-iterator": "^4.0",
                 "phpunit/php-invoker": "^4.0",
                 "phpunit/php-text-template": "^3.0",
@@ -2528,15 +2532,15 @@
                 "sebastian/comparator": "^5.0",
                 "sebastian/diff": "^5.0",
                 "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.0",
-                "sebastian/global-state": "^6.0",
+                "sebastian/exporter": "^5.1",
+                "sebastian/global-state": "^6.0.1",
                 "sebastian/object-enumerator": "^5.0",
                 "sebastian/recursion-context": "^5.0",
                 "sebastian/type": "^4.0",
                 "sebastian/version": "^4.0"
             },
             "suggest": {
-                "ext-soap": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -2544,7 +2548,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.0-dev"
+                    "dev-main": "10.4-dev"
                 }
             },
             "autoload": {
@@ -2575,7 +2579,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.14"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.4.2"
             },
             "funding": [
                 {
@@ -2591,7 +2596,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T05:37:49+00:00"
+            "time": "2023-10-26T07:21:45+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -2872,16 +2877,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2db5010a484d53ebf536087a70b4a5423c102372",
+                "reference": "2db5010a484d53ebf536087a70b4a5423c102372",
                 "shasum": ""
             },
             "require": {
@@ -2892,7 +2897,7 @@
                 "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.3"
             },
             "type": "library",
             "extra": {
@@ -2936,7 +2941,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.1"
             },
             "funding": [
                 {
@@ -2944,20 +2950,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:07:16+00:00"
+            "time": "2023-08-14T13:18:12+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.0.0",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
+                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68cfb347a44871f01e33ab0ef8215966432f6957",
+                "reference": "68cfb347a44871f01e33ab0ef8215966432f6957",
                 "shasum": ""
             },
             "require": {
@@ -2970,7 +2976,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "3.1-dev"
                 }
             },
             "autoload": {
@@ -2993,7 +2999,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.1.0"
             },
             "funding": [
                 {
@@ -3001,20 +3008,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:47+00:00"
+            "time": "2023-09-28T11:50:59+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.0",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f"
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/70dd1b20bc198da394ad542e988381b44e64e39f",
-                "reference": "70dd1b20bc198da394ad542e988381b44e64e39f",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
+                "reference": "912dc2fbe3e3c1e7873313cc801b100b6c68c87b",
                 "shasum": ""
             },
             "require": {
@@ -3059,7 +3066,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.3"
             },
             "funding": [
                 {
@@ -3067,20 +3075,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:00:31+00:00"
+            "time": "2023-05-01T07:48:21+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc"
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b6f3694c6386c7959915a0037652e0c40f6f69cc",
-                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/43c751b41d74f96cbbd4e07b7aec9675651e2951",
+                "reference": "43c751b41d74f96cbbd4e07b7aec9675651e2951",
                 "shasum": ""
             },
             "require": {
@@ -3122,7 +3130,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.1"
             },
             "funding": [
                 {
@@ -3130,20 +3139,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:03:04+00:00"
+            "time": "2023-04-11T05:39:26+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.0.0",
+            "version": "5.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
+                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64f51654862e0f5e318db7e9dcc2292c63cdbddc",
+                "reference": "64f51654862e0f5e318db7e9dcc2292c63cdbddc",
                 "shasum": ""
             },
             "require": {
@@ -3157,7 +3166,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -3199,7 +3208,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.1"
             },
             "funding": [
                 {
@@ -3207,20 +3217,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:49+00:00"
+            "time": "2023-09-24T13:22:09+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/7ea9ead78f6d380d2a667864c132c2f7b83055e4",
+                "reference": "7ea9ead78f6d380d2a667864c132c2f7b83055e4",
                 "shasum": ""
             },
             "require": {
@@ -3260,7 +3270,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.1"
             },
             "funding": [
                 {
@@ -3268,20 +3279,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:07:38+00:00"
+            "time": "2023-07-19T07:19:23+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
+                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/649e40d279e243d985aa8fb6e74dd5bb28dc185d",
+                "reference": "649e40d279e243d985aa8fb6e74dd5bb28dc185d",
                 "shasum": ""
             },
             "require": {
@@ -3317,7 +3328,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.1"
             },
             "funding": [
                 {
@@ -3325,7 +3337,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:02+00:00"
+            "time": "2023-08-31T09:25:50+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -3674,16 +3686,16 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.1.5",
+            "version": "3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43"
+                "reference": "96be97e664c87613121d073ea39af4c74e57a7f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/13f76acef5362d15c71ae1ac6350cc3df5e25e43",
-                "reference": "13f76acef5362d15c71ae1ac6350cc3df5e25e43",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/96be97e664c87613121d073ea39af4c74e57a7f8",
+                "reference": "96be97e664c87613121d073ea39af4c74e57a7f8",
                 "shasum": ""
             },
             "require": {
@@ -3721,7 +3733,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.1.5"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.2.2"
             },
             "funding": [
                 {
@@ -3733,7 +3745,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-24T13:43:51+00:00"
+            "time": "2023-11-14T14:08:51+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -3794,23 +3806,23 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.2.7",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "cbad09eb8925b6ad4fb721c7a179344dc4a19d45"
+                "reference": "0d14a9f6d04d4ac38a8cea1171f4554e325dae92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/cbad09eb8925b6ad4fb721c7a179344dc4a19d45",
-                "reference": "cbad09eb8925b6ad4fb721c7a179344dc4a19d45",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0d14a9f6d04d4ac38a8cea1171f4554e325dae92",
+                "reference": "0d14a9f6d04d4ac38a8cea1171f4554e325dae92",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/service-contracts": "^2.5|^3",
                 "symfony/string": "^5.4|^6.0"
             },
             "conflict": {
@@ -3831,12 +3843,6 @@
                 "symfony/lock": "^5.4|^6.0",
                 "symfony/process": "^5.4|^6.0",
                 "symfony/var-dumper": "^5.4|^6.0"
-            },
-            "suggest": {
-                "psr/log": "For using the console logger",
-                "symfony/event-dispatcher": "",
-                "symfony/lock": "",
-                "symfony/process": ""
             },
             "type": "library",
             "autoload": {
@@ -3865,12 +3871,12 @@
             "homepage": "https://symfony.com",
             "keywords": [
                 "cli",
-                "command line",
+                "command-line",
                 "console",
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.2.7"
+                "source": "https://github.com/symfony/console/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -3886,20 +3892,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-25T17:00:03+00:00"
+            "time": "2023-10-31T08:09:35+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.2.1",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
-                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
@@ -3908,7 +3914,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3937,7 +3943,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -3953,20 +3959,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:25:55+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.2.7",
+            "version": "v6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "82b6c62b959f642d000456f08c6d219d749215b3"
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/82b6c62b959f642d000456f08c6d219d749215b3",
-                "reference": "82b6c62b959f642d000456f08c6d219d749215b3",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
                 "shasum": ""
             },
             "require": {
@@ -4000,7 +4006,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.2.7"
+                "source": "https://github.com/symfony/filesystem/tree/v6.3.1"
             },
             "funding": [
                 {
@@ -4016,20 +4022,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:44:56+00:00"
+            "time": "2023-06-01T08:30:39+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
-                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
+                "reference": "ea208ce43cbb04af6867b4fdddb1bdbf84cc28cb",
                 "shasum": ""
             },
             "require": {
@@ -4044,7 +4050,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4082,7 +4088,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4098,20 +4104,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354"
+                "reference": "875e90aeea2777b6f135677f618529449334a612"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/511a08c03c1960e08a883f4cffcacd219b758354",
-                "reference": "511a08c03c1960e08a883f4cffcacd219b758354",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/875e90aeea2777b6f135677f618529449334a612",
+                "reference": "875e90aeea2777b6f135677f618529449334a612",
                 "shasum": ""
             },
             "require": {
@@ -4123,7 +4129,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4163,7 +4169,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4179,20 +4185,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6"
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/19bd1e4fcd5b91116f14d8533c57831ed00571b6",
-                "reference": "19bd1e4fcd5b91116f14d8533c57831ed00571b6",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
+                "reference": "8c4ad05dd0120b6a53c1ca374dca2ad0a1c4ed92",
                 "shasum": ""
             },
             "require": {
@@ -4204,7 +4210,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4247,7 +4253,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4263,20 +4269,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-01-26T09:26:14+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.27.0",
+            "version": "v1.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534"
+                "reference": "42292d99c55abe617799667f454222c54c60e229"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
-                "reference": "8ad114f6b39e2c98a8b0e3bd907732c207c2b534",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/42292d99c55abe617799667f454222c54c60e229",
+                "reference": "42292d99c55abe617799667f454222c54c60e229",
                 "shasum": ""
             },
             "require": {
@@ -4291,7 +4297,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.27-dev"
+                    "dev-main": "1.28-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -4330,7 +4336,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.27.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.28.0"
             },
             "funding": [
                 {
@@ -4346,20 +4352,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-03T14:55:06+00:00"
+            "time": "2023-07-28T09:04:16+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.2.1",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "a8c9cedf55f314f3a186041d19537303766df09a"
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a8c9cedf55f314f3a186041d19537303766df09a",
-                "reference": "a8c9cedf55f314f3a186041d19537303766df09a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
+                "reference": "b3313c2dbffaf71c8de2934e2ea56ed2291a3838",
                 "shasum": ""
             },
             "require": {
@@ -4369,13 +4375,10 @@
             "conflict": {
                 "ext-psr": "<1.1|>=2"
             },
-            "suggest": {
-                "symfony/service-implementation": ""
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4415,7 +4418,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.4.0"
             },
             "funding": [
                 {
@@ -4431,20 +4434,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:32:47+00:00"
+            "time": "2023-07-30T20:28:31+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.2.7",
+            "version": "v6.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "67b8c1eec78296b85dc1c7d9743830160218993d"
+                "reference": "13880a87790c76ef994c91e87efb96134522577a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/67b8c1eec78296b85dc1c7d9743830160218993d",
-                "reference": "67b8c1eec78296b85dc1c7d9743830160218993d",
+                "url": "https://api.github.com/repos/symfony/string/zipball/13880a87790c76ef994c91e87efb96134522577a",
+                "reference": "13880a87790c76ef994c91e87efb96134522577a",
                 "shasum": ""
             },
             "require": {
@@ -4455,13 +4458,13 @@
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": "<2.0"
+                "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
                 "symfony/intl": "^6.2",
-                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
             "type": "library",
@@ -4501,7 +4504,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.2.7"
+                "source": "https://github.com/symfony/string/tree/v6.3.8"
             },
             "funding": [
                 {
@@ -4517,20 +4520,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-24T10:42:00+00:00"
+            "time": "2023-11-09T08:28:21+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -4559,7 +4562,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -4567,26 +4570,26 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.7.7",
+            "version": "5.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e028ba46ba0d7f9a78bc3201c251e137383e145f"
+                "reference": "2897ba636551a8cb61601cc26f6ccfbba6c36591"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e028ba46ba0d7f9a78bc3201c251e137383e145f",
-                "reference": "e028ba46ba0d7f9a78bc3201c251e137383e145f",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/2897ba636551a8cb61601cc26f6ccfbba6c36591",
+                "reference": "2897ba636551a8cb61601cc26f6ccfbba6c36591",
                 "shasum": ""
             },
             "require": {
                 "amphp/amp": "^2.4.2",
                 "amphp/byte-stream": "^1.5",
-                "composer/package-versions-deprecated": "^1.10.0",
+                "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
@@ -4601,17 +4604,21 @@
                 "felixfbecker/language-server-protocol": "^1.5.2",
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.13",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
+                "nikic/php-parser": "^4.16",
+                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
                 "sebastian/diff": "^4.0 || ^5.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
-                "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0"
+                "symfony/console": "^4.1.6 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0"
+            },
+            "conflict": {
+                "nikic/php-parser": "4.17.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
+                "amphp/phpunit-util": "^2.0",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "brianium/paratest": "^6.9",
                 "ext-curl": "*",
@@ -4624,7 +4631,7 @@
                 "psalm/plugin-phpunit": "^0.18",
                 "slevomat/coding-standard": "^8.4",
                 "squizlabs/php_codesniffer": "^3.6",
-                "symfony/process": "^4.4 || ^5.0 || ^6.0"
+                "symfony/process": "^4.4 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
                 "ext-curl": "In order to send data to shepherd",
@@ -4637,7 +4644,7 @@
                 "psalm-refactor",
                 "psalter"
             ],
-            "type": "library",
+            "type": "project",
             "extra": {
                 "branch-alias": {
                     "dev-master": "5.x-dev",
@@ -4669,31 +4676,32 @@
                 "static analysis"
             ],
             "support": {
+                "docs": "https://psalm.dev/docs",
                 "issues": "https://github.com/vimeo/psalm/issues",
-                "source": "https://github.com/vimeo/psalm/tree/5.7.7"
+                "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2023-02-25T01:05:07+00:00"
+            "time": "2023-11-22T20:38:47+00:00"
         },
         {
             "name": "webimpress/coding-standard",
-            "version": "1.2.4",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webimpress/coding-standard.git",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9"
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
-                "reference": "cd0c4b0b97440c337c1f7da17b524674ca2f9ca9",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/b26557e2386711ecb74f22718f4b4bde5ddbc899",
+                "reference": "b26557e2386711ecb74f22718f4b4bde5ddbc899",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.3 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.6.2"
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5.13"
+                "phpunit/phpunit": "^9.6.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -4719,7 +4727,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webimpress/coding-standard/issues",
-                "source": "https://github.com/webimpress/coding-standard/tree/1.2.4"
+                "source": "https://github.com/webimpress/coding-standard/tree/1.3.1"
             },
             "funding": [
                 {
@@ -4727,7 +4735,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-15T19:52:12+00:00"
+            "time": "2023-03-09T15:05:18+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4800,5 +4808,5 @@
     "platform-overrides": {
         "php": "8.1.99"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7ec69d697bed2d8909ba6da903e7835",
+    "content-hash": "e32dfb6bb9f0668369720a3b3f2b9ed0",
     "packages": [
         {
             "name": "laminas/laminas-code",
@@ -4802,7 +4802,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0",
+        "ext-simplexml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,12 +3,20 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
-    colors="true">
-    <coverage>
+    cacheDirectory=".phpunit.cache"
+    displayDetailsOnIncompleteTests="true"
+    displayDetailsOnSkippedTests="true"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+    displayDetailsOnTestsThatTriggerErrors="true"
+    displayDetailsOnTestsThatTriggerNotices="true"
+    displayDetailsOnTestsThatTriggerWarnings="true"
+    colors="true"
+>
+    <source>
         <include>
             <directory suffix=".php">./src</directory>
         </include>
-    </coverage>
+    </source>
 
     <testsuites>
         <testsuite name="laminas-xmlrpc Test Suite">

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,32 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
+<files psalm-version="5.16.0@2897ba636551a8cb61601cc26f6ccfbba6c36591">
   <file src="src/AbstractValue.php">
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>! static::$generator</code>
       <code>static::$generator</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="4">
+    <InvalidArgument>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </InvalidArgument>
-    <InvalidMethodCall occurrences="1">
+    <InvalidMethodCall>
       <code>children</code>
     </InvalidMethodCall>
-    <InvalidPropertyFetch occurrences="1">
-      <code>$value-&gt;member</code>
+    <InvalidPropertyFetch>
+      <code><![CDATA[$value->member]]></code>
     </InvalidPropertyFetch>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>createSimpleXMLElement</code>
     </MissingReturnType>
-    <MixedArgument occurrences="20">
+    <MixedArgument>
       <code>$element</code>
-      <code>$member-&gt;value</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
+      <code><![CDATA[$member->value]]></code>
       <code>$value</code>
       <code>$value</code>
       <code>$value</code>
@@ -42,7 +38,7 @@
       <code>$value</code>
       <code>$value</code>
     </MixedArgument>
-    <MixedAssignment occurrences="7">
+    <MixedAssignment>
       <code>$data</code>
       <code>$element</code>
       <code>$key</code>
@@ -51,75 +47,61 @@
       <code>$value</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedPropertyFetch occurrences="4">
-      <code>$data-&gt;value</code>
-      <code>$member-&gt;name</code>
-      <code>$member-&gt;name</code>
-      <code>$member-&gt;value</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$data->value]]></code>
+      <code><![CDATA[$member->name]]></code>
+      <code><![CDATA[$member->name]]></code>
+      <code><![CDATA[$member->value]]></code>
     </MixedPropertyFetch>
-    <NullReference occurrences="2">
+    <NullReference>
       <code>$type</code>
       <code>$value</code>
     </NullReference>
-    <PossiblyFalseArgument occurrences="12">
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-      <code>$xml-&gt;asXML()</code>
-    </PossiblyFalseArgument>
-    <PossiblyInvalidArgument occurrences="2">
-      <code>$e-&gt;getCode()</code>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$e->getCode()]]></code>
       <code>$xml</code>
     </PossiblyInvalidArgument>
-    <PossiblyInvalidMethodCall occurrences="1">
+    <PossiblyInvalidMethodCall>
       <code>asXML</code>
     </PossiblyInvalidMethodCall>
-    <RedundantCondition occurrences="2">
-      <code>! empty($value) &amp;&amp; is_array($value)</code>
+    <RedundantCondition>
+      <code><![CDATA[! empty($value) && is_array($value)]]></code>
       <code>is_array($value)</code>
     </RedundantCondition>
-    <ReferenceConstraintViolation occurrences="1">
+    <ReferenceConstraintViolation>
       <code>$type</code>
     </ReferenceConstraintViolation>
-    <UndefinedMethod occurrences="1">
+    <UndefinedMethod>
       <code>generate</code>
     </UndefinedMethod>
   </file>
   <file src="src/Client.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>Client</code>
     </DeprecatedInterface>
-    <DocblockTypeContradiction occurrences="2">
-      <code>$httpRequest-&gt;getUriString() === null</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[$httpRequest->getUriString() === null]]></code>
       <code>is_array($params)</code>
     </DocblockTypeContradiction>
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$method</code>
     </InvalidArgument>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$type</code>
     </MixedArgument>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$param</code>
       <code>$signature</code>
       <code>$type</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>ServerProxy</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;proxyCache[$namespace]</code>
-      <code>$this-&gt;proxyCache[$namespace]</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->proxyCache[$namespace]]]></code>
+      <code><![CDATA[$this->proxyCache[$namespace]]]></code>
     </MixedReturnStatement>
-    <PossiblyInvalidMethodCall occurrences="6">
+    <PossiblyInvalidMethodCall>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
@@ -127,10 +109,10 @@
       <code>has</code>
       <code>has</code>
     </PossiblyInvalidMethodCall>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>getMessage</code>
     </PossiblyNullReference>
-    <PossiblyUndefinedMethod occurrences="6">
+    <PossiblyUndefinedMethod>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
       <code>addHeaderLine</code>
@@ -138,76 +120,80 @@
       <code>has</code>
       <code>has</code>
     </PossiblyUndefinedMethod>
-    <PossiblyUndefinedVariable occurrences="2">
+    <PossiblyUndefinedVariable>
       <code>$signatures</code>
       <code>$signatures</code>
     </PossiblyUndefinedVariable>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PossiblyUnusedReturnValue>
+      <code>ServerIntrospection</code>
+      <code>\Laminas\Http\Client</code>
+    </PossiblyUnusedReturnValue>
+    <PropertyNotSetInConstructor>
       <code>$lastRequest</code>
       <code>$lastResponse</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
-    <UnusedFunctionCall occurrences="3">
+    <UnusedFunctionCall>
       <code>iconv_set_encoding</code>
       <code>iconv_set_encoding</code>
       <code>iconv_set_encoding</code>
     </UnusedFunctionCall>
   </file>
   <file src="src/Client/ServerIntrospection.php">
-    <InvalidOperand occurrences="1">
+    <InvalidOperand>
       <code>$method</code>
     </InvalidOperand>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$method</code>
     </MixedArgument>
-    <MixedArrayOffset occurrences="2">
+    <MixedArrayOffset>
       <code>$signatures[$method]</code>
       <code>$signatures[$methods[$i]]</code>
     </MixedArrayOffset>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$method</code>
       <code>$method</code>
       <code>$signature</code>
       <code>$signatures[$methods[$i]]</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>array</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;system-&gt;listMethods()</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->system->listMethods()]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Client/ServerProxy.php">
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>ServerProxy</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;cache[$namespace]</code>
-      <code>$this-&gt;cache[$namespace]</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->cache[$namespace]]]></code>
+      <code><![CDATA[$this->cache[$namespace]]]></code>
     </MixedReturnStatement>
   </file>
   <file src="src/Fault.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($fault)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$code</code>
       <code>$message</code>
       <code>$message</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$struct['faultCode']</code>
-      <code>$struct['faultString']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$struct['faultCode']]]></code>
+      <code><![CDATA[$struct['faultString']]]></code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="1">
-      <code>$this-&gt;internal[$code]</code>
+    <MixedArrayOffset>
+      <code><![CDATA[$this->internal[$code]]]></code>
     </MixedArrayOffset>
-    <MixedArrayTypeCoercion occurrences="1">
-      <code>$this-&gt;internal[$code]</code>
+    <MixedArrayTypeCoercion>
+      <code><![CDATA[$this->internal[$code]]]></code>
     </MixedArrayTypeCoercion>
-    <MixedAssignment occurrences="9">
+    <MixedAssignment>
       <code>$code</code>
       <code>$errors</code>
       <code>$message</code>
@@ -216,56 +202,57 @@
       <code>$message</code>
       <code>$message</code>
       <code>$struct</code>
-      <code>$structXml</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="3">
-      <code>asXML</code>
+    <MixedMethodCall>
       <code>closeElement</code>
       <code>openElement</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="3">
+    <MixedOperand>
       <code>$errors</code>
-      <code>$item-&gt;message</code>
+      <code><![CDATA[$item->message]]></code>
       <code>$result</code>
     </MixedOperand>
-    <MixedPropertyFetch occurrences="4">
-      <code>$item-&gt;message</code>
-      <code>$item-&gt;message</code>
-      <code>$xml-&gt;fault-&gt;value</code>
-      <code>$xml-&gt;fault-&gt;value-&gt;struct</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$item->message]]></code>
+      <code><![CDATA[$item->message]]></code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="1">
-      <code>$generator-&gt;flush()</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$generator->flush()]]></code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$code</code>
     </PossiblyInvalidArgument>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$xml->fault->value->struct]]></code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference>
+      <code>asXML</code>
+    </PossiblyNullReference>
+    <RedundantCastGivenDocblockType>
       <code>(int) $code</code>
       <code>(string) $message</code>
     </RedundantCastGivenDocblockType>
-    <UnsafeInstantiation occurrences="1">
+    <UnsafeInstantiation>
       <code>new static()</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Generator/AbstractGenerator.php">
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>closeXmlElement</code>
       <code>openXmlElement</code>
       <code>writeTextData</code>
     </MissingReturnType>
   </file>
   <file src="src/Generator/DomDocument.php">
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>writeTextData</code>
     </MissingReturnType>
   </file>
   <file src="src/Generator/GeneratorInterface.php">
-    <MissingReturnType occurrences="6">
-      <code>__toString</code>
+    <MissingReturnType>
       <code>closeElement</code>
       <code>flush</code>
       <code>getEncoding</code>
@@ -274,37 +261,37 @@
     </MissingReturnType>
   </file>
   <file src="src/Generator/XmlWriter.php">
-    <InvalidClass occurrences="1">
+    <InvalidClass>
       <code>XMLWriter</code>
     </InvalidClass>
-    <InvalidPropertyAssignmentValue occurrences="1">
+    <InvalidPropertyAssignmentValue>
       <code>new \XMLWriter()</code>
     </InvalidPropertyAssignmentValue>
-    <TooManyArguments occurrences="1">
+    <TooManyArguments>
       <code>flush</code>
     </TooManyArguments>
-    <UndefinedMethod occurrences="3">
+    <UndefinedMethod>
       <code>endElement</code>
       <code>startElement</code>
       <code>text</code>
     </UndefinedMethod>
   </file>
   <file src="src/Request.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$request</code>
     </ArgumentTypeCoercion>
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>! is_string($method)</code>
       <code>is_string($request)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="1">
+    <MixedArgument>
       <code>$type</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="2">
-      <code>$param['type']</code>
-      <code>$param['value']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$param['type']]]></code>
+      <code><![CDATA[$param['value']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="10">
+    <MixedAssignment>
       <code>$arg</code>
       <code>$arg</code>
       <code>$arg</code>
@@ -316,42 +303,50 @@
       <code>$types[]</code>
       <code>$value</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="4">
-      <code>children</code>
+    <MixedMethodCall>
       <code>closeElement</code>
       <code>generateXml</code>
       <code>openElement</code>
     </MixedMethodCall>
-    <MixedPropertyFetch occurrences="1">
-      <code>$param-&gt;value</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$param->value]]></code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="1">
-      <code>$generator-&gt;flush()</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$generator->flush()]]></code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="3">
+    <PossiblyNullIterator>
+      <code><![CDATA[$xml->params->children()]]></code>
+    </PossiblyNullIterator>
+    <PossiblyUnusedProperty>
+      <code>$xml</code>
+    </PossiblyUnusedProperty>
+    <PropertyNotSetInConstructor>
       <code>$fault</code>
       <code>$method</code>
       <code>$xml</code>
     </PropertyNotSetInConstructor>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType>
       <code>is_array($args)</code>
-      <code>is_array($this-&gt;xmlRpcParams)</code>
+      <code><![CDATA[is_array($this->xmlRpcParams)]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Request/Http.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>null === $this-&gt;headers</code>
+    <DocblockTypeContradiction>
+      <code><![CDATA[null === $this->headers]]></code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$value</code>
     </MixedAssignment>
-    <MixedOperand occurrences="1">
+    <MixedOperand>
       <code>$value</code>
     </MixedOperand>
-    <PropertyNotSetInConstructor occurrences="4">
+    <PossiblyUnusedMethod>
+      <code>getFullRequest</code>
+    </PossiblyUnusedMethod>
+    <PropertyNotSetInConstructor>
       <code>$headers</code>
       <code>$xml</code>
       <code>Http</code>
@@ -359,379 +354,383 @@
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Request/Stdin.php">
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>Stdin</code>
       <code>Stdin</code>
     </PropertyNotSetInConstructor>
+    <UnusedClass>
+      <code>Stdin</code>
+    </UnusedClass>
   </file>
   <file src="src/Response.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>is_string($response)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="1">
+    <InvalidPropertyFetch>
+      <code><![CDATA[$xml->fault]]></code>
+      <code><![CDATA[$xml->params]]></code>
+    </InvalidPropertyFetch>
+    <MixedAssignment>
       <code>$valueXml</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="5">
+    <MixedMethodCall>
       <code>asXML</code>
       <code>closeElement</code>
       <code>closeElement</code>
       <code>openElement</code>
       <code>openElement</code>
     </MixedMethodCall>
-    <MixedPropertyFetch occurrences="2">
-      <code>$xml-&gt;params-&gt;param</code>
-      <code>$xml-&gt;params-&gt;param-&gt;value</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$xml->params->param->value]]></code>
+      <code><![CDATA[$xml->params->param->value]]></code>
     </MixedPropertyFetch>
-    <MixedReturnStatement occurrences="1">
-      <code>$generator-&gt;flush()</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$generator->flush()]]></code>
     </MixedReturnStatement>
-    <PossiblyInvalidPropertyFetch occurrences="2">
-      <code>$xml-&gt;fault</code>
-      <code>$xml-&gt;params</code>
-    </PossiblyInvalidPropertyFetch>
+    <PossiblyUnusedProperty>
+      <code>$type</code>
+    </PossiblyUnusedProperty>
+    <TypeDoesNotContainType>
+      <code><![CDATA[! isset($xml->params)]]></code>
+    </TypeDoesNotContainType>
   </file>
   <file src="src/Server.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$type</code>
     </ArgumentTypeCoercion>
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>Server</code>
     </DeprecatedInterface>
-    <DeprecatedMethod occurrences="3">
+    <DeprecatedMethod>
       <code>_buildSignature</code>
       <code>_buildSignature</code>
       <code>_dispatch</code>
     </DeprecatedMethod>
-    <DocblockTypeContradiction occurrences="2">
+    <DocblockTypeContradiction>
       <code>! $request</code>
       <code>! $request</code>
     </DocblockTypeContradiction>
-    <ImplementedReturnTypeMismatch occurrences="2">
+    <ImplementedReturnTypeMismatch>
       <code>Server</code>
       <code>array</code>
     </ImplementedReturnTypeMismatch>
-    <InvalidNullableReturnType occurrences="1">
+    <InvalidNullableReturnType>
       <code>Response|Fault</code>
     </InvalidNullableReturnType>
-    <InvalidParamDefault occurrences="1">
+    <InvalidParamDefault>
       <code>Request</code>
     </InvalidParamDefault>
-    <InvalidReturnStatement occurrences="2">
-      <code>$this-&gt;sendArgumentsToAllMethods</code>
-      <code>$this-&gt;table</code>
+    <InvalidReturnStatement>
+      <code><![CDATA[$this->sendArgumentsToAllMethods]]></code>
+      <code><![CDATA[$this->table]]></code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="2">
+    <InvalidReturnType>
       <code>array</code>
       <code>self</code>
     </InvalidReturnType>
-    <InvalidStringClass occurrences="1">
+    <InvalidStringClass>
       <code>new $responseClass($return)</code>
     </InvalidStringClass>
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>new $responseClass($return)</code>
     </LessSpecificReturnStatement>
-    <MixedArgument occurrences="3">
+    <MixedArgument>
       <code>$argv</code>
       <code>$method</code>
       <code>$reflection</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="2">
+    <MixedArgumentTypeCoercion>
       <code>$key</code>
       <code>$key</code>
     </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="5">
+    <MixedAssignment>
       <code>$method</code>
       <code>$reflection</code>
       <code>$return</code>
       <code>$sigParams</code>
       <code>$signature</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>Server\System</code>
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>getParameters</code>
       <code>new $request()</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$this-&gt;system</code>
-      <code>$this-&gt;typeMap[$type]</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->typeMap[$type]]]></code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType occurrences="3">
+    <MoreSpecificImplementedParamType>
       <code>$class</code>
       <code>$fault</code>
       <code>$request</code>
     </MoreSpecificImplementedParamType>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>Response</code>
     </MoreSpecificReturnType>
-    <PossiblyInvalidPropertyAssignmentValue occurrences="1">
+    <PossiblyInvalidPropertyAssignmentValue>
       <code>$response</code>
     </PossiblyInvalidPropertyAssignmentValue>
-    <PossiblyNullArgument occurrences="1">
+    <PossiblyNullArgument>
       <code>$argv</code>
     </PossiblyNullArgument>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>getInvokeArguments</code>
       <code>setEncoding</code>
     </PossiblyNullReference>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PossiblyUnusedMethod>
+      <code>isSubclassOf</code>
+    </PossiblyUnusedMethod>
+    <PropertyNotSetInConstructor>
       <code>$response</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <RedundantCastGivenDocblockType>
       <code>(bool) $flag</code>
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>$this-&gt;sendArgumentsToAllMethods()</code>
+    <RedundantConditionGivenDocblockType>
+      <code><![CDATA[$this->sendArgumentsToAllMethods()]]></code>
       <code>is_object($definition)</code>
     </RedundantConditionGivenDocblockType>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;system</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="1">
-      <code>$this-&gt;system</code>
-    </UndefinedThisPropertyFetch>
   </file>
   <file src="src/Server/Fault.php">
-    <DocblockTypeContradiction occurrences="1">
+    <DocblockTypeContradiction>
       <code>! is_string($class)</code>
     </DocblockTypeContradiction>
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$class</code>
       <code>$class</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$code</code>
     </PossiblyInvalidArgument>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass>
       <code>$observer::observe($this)</code>
     </UndefinedClass>
-    <UnsafeInstantiation occurrences="1">
+    <UnsafeInstantiation>
       <code>new static($e)</code>
     </UnsafeInstantiation>
   </file>
   <file src="src/Server/System.php">
-    <InvalidMethodCall occurrences="5">
+    <InvalidMethodCall>
       <code>getMethod</code>
       <code>getMethod</code>
       <code>getMethods</code>
       <code>hasMethod</code>
       <code>hasMethod</code>
     </InvalidMethodCall>
-    <InvalidScalarArgument occurrences="1">
+    <InvalidScalarArgument>
       <code>1</code>
     </InvalidScalarArgument>
-    <MixedArgument occurrences="2">
-      <code>$method['methodName']</code>
+    <MixedArgument>
+      <code><![CDATA[$method['methodName']]]></code>
       <code>$table</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="3">
-      <code>$method['methodName']</code>
-      <code>$method['params']</code>
-      <code>$method['prototypes']</code>
+    <MixedArrayAccess>
+      <code><![CDATA[$method['methodName']]]></code>
+      <code><![CDATA[$method['params']]]></code>
+      <code><![CDATA[$method['prototypes']]]></code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="4">
+    <MixedAssignment>
       <code>$method</code>
       <code>$method</code>
       <code>$responses[]</code>
       <code>$table</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>getMethodHelp</code>
       <code>toArray</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
-      <code>$method['prototypes']</code>
-      <code>$table-&gt;getMethod($method)-&gt;getMethodHelp()</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$method['prototypes']]]></code>
+      <code><![CDATA[$table->getMethod($method)->getMethodHelp()]]></code>
     </MixedReturnStatement>
-    <PossiblyNullOperand occurrences="1">
+    <PossiblyNullOperand>
       <code>var_export($methods, 1)</code>
     </PossiblyNullOperand>
-    <PossiblyUndefinedMethod occurrences="2">
+    <PossiblyUndefinedMethod>
       <code>getCode</code>
       <code>getMessage</code>
     </PossiblyUndefinedMethod>
+    <PossiblyUnusedMethod>
+      <code>listMethods</code>
+      <code>methodHelp</code>
+      <code>methodSignature</code>
+      <code>multicall</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Value/AbstractCollection.php">
-    <MixedArrayAssignment occurrences="1">
-      <code>$this-&gt;value[$key]</code>
+    <MixedArrayAssignment>
+      <code><![CDATA[$this->value[$key]]]></code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$value</code>
       <code>$value</code>
       <code>$values[$key]</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getValue</code>
     </MixedMethodCall>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>AbstractCollection</code>
       <code>AbstractCollection</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(array) $value</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Value/AbstractScalar.php">
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>closeElement</code>
       <code>closeElement</code>
       <code>openElement</code>
     </MixedMethodCall>
+    <PossiblyUnusedMethod>
+      <code>generate</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="src/Value/ArrayValue.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$val</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="5">
+    <MixedMethodCall>
       <code>closeElement</code>
       <code>closeElement</code>
       <code>generateXml</code>
       <code>openElement</code>
       <code>openElement</code>
     </MixedMethodCall>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PossiblyUnusedMethod>
+      <code>generate</code>
+    </PossiblyUnusedMethod>
+    <PropertyNotSetInConstructor>
       <code>ArrayValue</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Value/Base64.php">
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;value</code>
+    <MixedArgument>
+      <code><![CDATA[$this->value]]></code>
     </MixedArgument>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Base64</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $value</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Value/BigInteger.php">
-    <ImplementedReturnTypeMismatch occurrences="1">
+    <ImplementedReturnTypeMismatch>
       <code>string</code>
     </ImplementedReturnTypeMismatch>
-    <MixedArgument occurrences="1">
-      <code>$value</code>
-    </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;value</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->value]]></code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>BigInteger</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Value/Boolean.php">
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Boolean</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Value/DateTime.php">
-    <MixedArgument occurrences="1">
-      <code>$value</code>
-    </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>int</code>
+    <MixedInferredReturnType>
+      <code>string</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;value</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->value]]></code>
     </MixedReturnStatement>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$e-&gt;getCode()</code>
+    <PossiblyInvalidArgument>
+      <code><![CDATA[$e->getCode()]]></code>
     </PossiblyInvalidArgument>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PossiblyUnusedProperty>
+      <code>$isoFormatString</code>
+    </PossiblyUnusedProperty>
+    <PropertyNotSetInConstructor>
       <code>DateTime</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Value/Double.php">
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Double</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(float) $value</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Value/Integer.php">
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>int</code>
     </MixedInferredReturnType>
-    <MixedReturnStatement occurrences="1">
-      <code>$this-&gt;value</code>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->value]]></code>
     </MixedReturnStatement>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Integer</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(int) $value</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Value/Nil.php">
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Nil</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Value/Struct.php">
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$val</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="5">
+    <MixedMethodCall>
       <code>closeElement</code>
       <code>closeElement</code>
       <code>generateXml</code>
       <code>openElement</code>
       <code>openElement</code>
     </MixedMethodCall>
-    <PropertyNotSetInConstructor occurrences="1">
+    <PossiblyUnusedMethod>
+      <code>generate</code>
+    </PossiblyUnusedMethod>
+    <PropertyNotSetInConstructor>
       <code>Struct</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="src/Value/Text.php">
-    <PropertyNotSetInConstructor occurrences="1">
+    <PropertyNotSetInConstructor>
       <code>Text</code>
     </PropertyNotSetInConstructor>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(string) $value</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="test/AbstractTestProvider.php">
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType>
       <code>array</code>
       <code>array</code>
     </MixedInferredReturnType>
   </file>
-  <file src="test/BigIntegerValueTest.php">
-    <MissingReturnType occurrences="3">
-      <code>testMarschalBigIntegerFromApacheXmlRpc</code>
-      <code>testMarschalBigIntegerFromXmlRpc</code>
-      <code>testMarshalsIntegerForI8ValueByDefaultIfSystemIs64Bit</code>
-    </MissingReturnType>
-    <UnusedVariable occurrences="2">
-      <code>$bigInteger</code>
-      <code>$bigInteger</code>
-    </UnusedVariable>
-  </file>
   <file src="test/ClientTest.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument>
       <code>$method</code>
-      <code>'1'</code>
-      <code>'add'</code>
+      <code><![CDATA['1']]></code>
+      <code><![CDATA['add']]></code>
     </InvalidArgument>
-    <MissingReturnType occurrences="3">
-      <code>mockHttpClient</code>
+    <MissingReturnType>
       <code>mockIntrospector</code>
       <code>setServerResponseTo</code>
     </MissingReturnType>
-    <MixedMethodCall occurrences="20">
+    <MixedMethodCall>
       <code>expects</code>
       <code>expects</code>
       <code>expects</code>
@@ -746,14 +745,14 @@
       <code>method</code>
       <code>method</code>
       <code>method</code>
-      <code>will</code>
-      <code>will</code>
-      <code>will</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
+      <code>willReturn</code>
       <code>with</code>
       <code>with</code>
       <code>with</code>
     </MixedMethodCall>
-    <UndefinedInterfaceMethod occurrences="15">
+    <UndefinedInterfaceMethod>
       <code>addResponse</code>
       <code>addResponse</code>
       <code>addResponse</code>
@@ -770,50 +769,59 @@
       <code>setResponse</code>
       <code>setResponse</code>
     </UndefinedInterfaceMethod>
-    <UndefinedThisPropertyAssignment occurrences="2">
-      <code>$this-&gt;mockedHttpClient</code>
-      <code>$this-&gt;mockedIntrospector</code>
+    <UndefinedThisPropertyAssignment>
+      <code><![CDATA[$this->mockedIntrospector]]></code>
     </UndefinedThisPropertyAssignment>
-    <UnusedVariable occurrences="2">
+    <UnusedVariable>
       <code>$signature</code>
       <code>$time</code>
     </UnusedVariable>
   </file>
   <file src="test/FaultTest.php">
-    <InvalidArgument occurrences="1">
-      <code>['foo']</code>
+    <InvalidArgument>
+      <code><![CDATA[['foo']]]></code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
-      <code>['foo']</code>
+    <InvalidCast>
+      <code><![CDATA[['foo']]]></code>
     </InvalidCast>
-    <MissingReturnType occurrences="3">
+    <MissingReturnType>
       <code>testLoadXmlThrowsExceptionOnInvalidInput2</code>
       <code>testLoadXmlThrowsExceptionOnInvalidInput3</code>
       <code>testLoadXmlThrowsExceptionOnInvalidInput4</code>
     </MissingReturnType>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>$member</code>
     </MixedAssignment>
-    <MixedPropertyFetch occurrences="7">
-      <code>$member-&gt;name</code>
-      <code>$member-&gt;value</code>
-      <code>$member-&gt;value-&gt;int</code>
-      <code>$member-&gt;value-&gt;string</code>
-      <code>$sx-&gt;fault-&gt;value</code>
-      <code>$sx-&gt;fault-&gt;value-&gt;struct</code>
-      <code>$sx-&gt;fault-&gt;value-&gt;struct-&gt;member</code>
+    <MixedPropertyFetch>
+      <code><![CDATA[$member->name]]></code>
+      <code><![CDATA[$member->value]]></code>
+      <code><![CDATA[$member->value->int]]></code>
+      <code><![CDATA[$member->value->string]]></code>
     </MixedPropertyFetch>
-    <PossiblyInvalidArgument occurrences="2">
+    <PossiblyInvalidArgument>
       <code>$xml</code>
       <code>$xml</code>
     </PossiblyInvalidArgument>
-    <UnusedVariable occurrences="2">
+    <PossiblyNullIterator>
+      <code><![CDATA[$sx->fault->value->struct->member]]></code>
+    </PossiblyNullIterator>
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$sx->fault->value]]></code>
+      <code><![CDATA[$sx->fault->value->struct]]></code>
+      <code><![CDATA[$sx->fault->value->struct->member]]></code>
+    </PossiblyNullPropertyFetch>
+    <RedundantCondition>
+      <code>assertNotFalse</code>
+      <code>assertNotFalse</code>
+      <code>assertNotFalse</code>
+    </RedundantCondition>
+    <UnusedVariable>
       <code>$parsed</code>
       <code>$value2</code>
     </UnusedVariable>
   </file>
   <file src="test/GeneratorTest.php">
-    <MissingReturnType occurrences="8">
+    <MissingReturnType>
       <code>assertXml</code>
       <code>testCreatingComplexXmlDocument</code>
       <code>testCreatingSingleElement</code>
@@ -823,35 +831,35 @@
       <code>testFlushingGeneratorFlushesEverything</code>
       <code>testSpecialCharsAreEncoded</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$generator-&gt;flush()</code>
+    <MixedArgument>
+      <code><![CDATA[$generator->flush()]]></code>
     </MixedArgument>
-    <MixedMethodCall occurrences="5">
+    <MixedMethodCall>
       <code>closeElement</code>
       <code>closeElement</code>
       <code>closeElement</code>
       <code>closeElement</code>
       <code>closeElement</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
-      <code>$actual-&gt;getEncoding()</code>
+    <MixedOperand>
+      <code><![CDATA[$actual->getEncoding()]]></code>
     </MixedOperand>
   </file>
   <file src="test/PhpInputMock.php">
-    <MissingParamType occurrences="5">
+    <MissingParamType>
       <code>$count</code>
       <code>$data</code>
       <code>$methodName</code>
       <code>$methodName</code>
       <code>$returnValue</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="4">
+    <MissingPropertyType>
       <code>$arguments</code>
       <code>$data</code>
       <code>$position</code>
       <code>$returnValues</code>
     </MissingPropertyType>
-    <MissingReturnType occurrences="8">
+    <MissingReturnType>
       <code>argumentsPassedTo</code>
       <code>methodWillReturn</code>
       <code>mockInput</code>
@@ -861,7 +869,7 @@
       <code>stream_read</code>
       <code>stream_stat</code>
     </MissingReturnType>
-    <MixedArgument occurrences="12">
+    <MixedArgument>
       <code>$count</code>
       <code>$count</code>
       <code>$methodName</code>
@@ -875,107 +883,116 @@
       <code>static::$returnValues</code>
       <code>static::$returnValues</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="5">
+    <MixedArrayAccess>
       <code>static::$arguments[$methodName]</code>
       <code>static::$returnValues[__FUNCTION__]</code>
       <code>static::$returnValues[__FUNCTION__]</code>
       <code>static::$returnValues[__FUNCTION__]</code>
       <code>static::$returnValues[__FUNCTION__]</code>
     </MixedArrayAccess>
-    <MixedArrayAssignment occurrences="5">
+    <MixedArrayAssignment>
       <code>static::$arguments[__FUNCTION__]</code>
       <code>static::$arguments[__FUNCTION__]</code>
       <code>static::$arguments[__FUNCTION__]</code>
       <code>static::$arguments[__FUNCTION__]</code>
       <code>static::$returnValues[$methodName]</code>
     </MixedArrayAssignment>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$data</code>
       <code>static::$data</code>
       <code>static::$returnValues[$methodName]</code>
     </MixedAssignment>
-    <UnusedFunctionCall occurrences="2">
+    <PossiblyUnusedMethod>
+      <code>stream_eof</code>
+      <code>stream_open</code>
+      <code>stream_read</code>
+      <code>stream_stat</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedProperty>
+      <code>$position</code>
+    </PossiblyUnusedProperty>
+    <UnusedFunctionCall>
       <code>stream_wrapper_restore</code>
       <code>stream_wrapper_unregister</code>
     </UnusedFunctionCall>
   </file>
   <file src="test/Request/HttpTest.php">
-    <MixedArrayAccess occurrences="2">
+    <MixedArrayAccess>
       <code>$mode</code>
       <code>$path</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
+    <MixedAssignment>
       <code>[$path, $mode]</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="3">
+    <MixedMethodCall>
       <code>getFullRequest</code>
       <code>getHeaders</code>
       <code>getRawRequest</code>
     </MixedMethodCall>
-    <MixedOperand occurrences="1">
-      <code>$this-&gt;xml</code>
+    <MixedOperand>
+      <code><![CDATA[$this->xml]]></code>
     </MixedOperand>
-    <PossiblyNullReference occurrences="1">
+    <PossiblyNullReference>
       <code>getCode</code>
     </PossiblyNullReference>
-    <UndefinedThisPropertyAssignment occurrences="3">
-      <code>$this-&gt;request</code>
-      <code>$this-&gt;server</code>
-      <code>$this-&gt;xml</code>
+    <UndefinedThisPropertyAssignment>
+      <code><![CDATA[$this->request]]></code>
+      <code><![CDATA[$this->server]]></code>
+      <code><![CDATA[$this->xml]]></code>
     </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="8">
-      <code>$this-&gt;request</code>
-      <code>$this-&gt;request</code>
-      <code>$this-&gt;request</code>
-      <code>$this-&gt;request</code>
-      <code>$this-&gt;server</code>
-      <code>$this-&gt;xml</code>
-      <code>$this-&gt;xml</code>
-      <code>$this-&gt;xml</code>
+    <UndefinedThisPropertyFetch>
+      <code><![CDATA[$this->request]]></code>
+      <code><![CDATA[$this->request]]></code>
+      <code><![CDATA[$this->request]]></code>
+      <code><![CDATA[$this->request]]></code>
+      <code><![CDATA[$this->server]]></code>
+      <code><![CDATA[$this->xml]]></code>
+      <code><![CDATA[$this->xml]]></code>
+      <code><![CDATA[$this->xml]]></code>
     </UndefinedThisPropertyFetch>
-    <UnusedForeachValue occurrences="1">
+    <UnusedForeachValue>
       <code>$value</code>
     </UnusedForeachValue>
   </file>
   <file src="test/Request/TestAsset/HTTPTestExtension.php">
-    <MixedAssignment occurrences="1">
-      <code>$this-&gt;method</code>
+    <MixedAssignment>
+      <code><![CDATA[$this->method]]></code>
     </MixedAssignment>
-    <PropertyNotSetInConstructor occurrences="3">
+    <PropertyNotSetInConstructor>
       <code>HTTPTestExtension</code>
       <code>HTTPTestExtension</code>
       <code>HTTPTestExtension</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/RequestTest.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>$method</code>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
+    <InvalidCast>
       <code>new stdClass()</code>
     </InvalidCast>
-    <MixedArrayAccess occurrences="2">
-      <code>$sx-&gt;params-&gt;param[0]</code>
-      <code>$sx-&gt;params-&gt;param[1]</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="1">
-      <code>$param</code>
-    </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getValue</code>
     </MixedMethodCall>
-    <MixedPropertyFetch occurrences="8">
-      <code>$param-&gt;{$type}</code>
-      <code>$sx-&gt;params-&gt;param</code>
-      <code>$sx-&gt;params-&gt;param[0]-&gt;value</code>
-      <code>$sx-&gt;params-&gt;param[0]-&gt;value-&gt;string</code>
-      <code>$sx-&gt;params-&gt;param[1]-&gt;value</code>
-      <code>$sx-&gt;params-&gt;param[1]-&gt;value-&gt;boolean</code>
-      <code>$sxl-&gt;params-&gt;param</code>
-      <code>$sxl-&gt;params-&gt;param-&gt;value</code>
-    </MixedPropertyFetch>
-    <PossiblyNullReference occurrences="8">
+    <PossiblyNullArgument>
+      <code>$result</code>
+      <code>$result</code>
+    </PossiblyNullArgument>
+    <PossiblyNullArrayAccess>
+      <code><![CDATA[$sx->params->param[0]]]></code>
+      <code><![CDATA[$sx->params->param[1]]]></code>
+    </PossiblyNullArrayAccess>
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$sx->params->param]]></code>
+      <code><![CDATA[$sx->params->param[0]->value]]></code>
+      <code><![CDATA[$sx->params->param[0]->value->string]]></code>
+      <code><![CDATA[$sx->params->param[1]->value]]></code>
+      <code><![CDATA[$sx->params->param[1]->value->boolean]]></code>
+      <code><![CDATA[$sxl->params->param]]></code>
+      <code><![CDATA[$sxl->params->param->value]]></code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference>
       <code>getCode</code>
       <code>getCode</code>
       <code>getCode</code>
@@ -985,84 +1002,96 @@
       <code>getMessage</code>
       <code>getMessage</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <RedundantConditionGivenDocblockType>
       <code>is_string($method)</code>
     </RedundantConditionGivenDocblockType>
-    <UnusedVariable occurrences="1">
+    <UnusedVariable>
       <code>$mName</code>
     </UnusedVariable>
   </file>
   <file src="test/ResponseTest.php">
-    <InvalidArgument occurrences="3">
+    <InvalidArgument>
       <code>$value</code>
-      <code>[$this, 'trackError']</code>
+      <code><![CDATA[[$this, 'trackError']]]></code>
       <code>new stdClass()</code>
     </InvalidArgument>
-    <InvalidCast occurrences="1">
+    <InvalidCast>
       <code>new stdClass()</code>
     </InvalidCast>
-    <MissingReturnType occurrences="2">
+    <MissingReturnType>
       <code>testLoadXmlCreatesFaultWithMissingNodes2</code>
       <code>testLoadXmlThrowsExceptionWithMissingNodes3</code>
     </MissingReturnType>
-    <MixedPropertyFetch occurrences="3">
-      <code>$sx-&gt;params-&gt;param</code>
-      <code>$sx-&gt;params-&gt;param-&gt;value</code>
-      <code>$sx-&gt;params-&gt;param-&gt;value-&gt;string</code>
-    </MixedPropertyFetch>
-    <PossiblyFalseArgument occurrences="3">
-      <code>$sxl-&gt;asXML()</code>
-      <code>$sxl-&gt;asXML()</code>
-      <code>$sxl-&gt;asXML()</code>
-    </PossiblyFalseArgument>
-    <PossiblyNullReference occurrences="4">
+    <PossiblyNullPropertyFetch>
+      <code><![CDATA[$sx->params->param]]></code>
+      <code><![CDATA[$sx->params->param->value]]></code>
+      <code><![CDATA[$sx->params->param->value->string]]></code>
+    </PossiblyNullPropertyFetch>
+    <PossiblyNullReference>
       <code>getCode</code>
       <code>getCode</code>
       <code>getCode</code>
       <code>getCode</code>
     </PossiblyNullReference>
-    <RedundantConditionGivenDocblockType occurrences="1">
+    <PossiblyUnusedMethod>
+      <code>trackError</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedParam>
+      <code>$error</code>
+    </PossiblyUnusedParam>
+    <RedundantCondition>
+      <code>assertNotFalse</code>
+      <code>assertNotFalse</code>
+      <code>assertNotFalse</code>
+      <code>assertNotFalse</code>
+    </RedundantCondition>
+    <RedundantConditionGivenDocblockType>
       <code>assertFalse</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="test/Server/CacheTest.php">
-    <MixedAssignment occurrences="2">
+    <MixedAssignment>
       <code>$actual</code>
       <code>$expected</code>
     </MixedAssignment>
   </file>
   <file src="test/Server/FaultTest.php">
-    <UnusedVariable occurrences="3">
+    <UnusedVariable>
       <code>$fault</code>
       <code>$fault</code>
       <code>$fault</code>
     </UnusedVariable>
   </file>
+  <file src="test/Server/TestAsset/Observer.php">
+    <PossiblyUnusedMethod>
+      <code>observe</code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/ServerTest.php">
-    <InvalidArgument occurrences="4">
+    <InvalidArgument>
       <code>$o</code>
       <code>$o</code>
       <code>$this</code>
-      <code>'foo'</code>
+      <code><![CDATA['foo']]></code>
     </InvalidArgument>
-    <InvalidMethodCall occurrences="1">
+    <InvalidMethodCall>
       <code>getMethod</code>
     </InvalidMethodCall>
-    <MissingReturnType occurrences="5">
+    <MissingReturnType>
       <code>testCanMarshalBase64Requests</code>
       <code>testHandle2</code>
       <code>testLoadFunctionsThrowsExceptionsWithBadData2</code>
       <code>testLoadFunctionsThrowsExceptionsWithBadData3</code>
       <code>testRequestResponseEncoding2</code>
     </MissingReturnType>
-    <MixedArgument occurrences="5">
+    <MixedArgument>
       <code>$help</code>
       <code>$methods</code>
       <code>$methods</code>
       <code>$methods</code>
       <code>$methods</code>
     </MixedArgument>
-    <MixedAssignment occurrences="13">
+    <MixedAssignment>
       <code>$actual</code>
       <code>$expected</code>
       <code>$help</code>
@@ -1077,93 +1106,107 @@
       <code>$response</code>
       <code>$response</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="2">
+    <MixedMethodCall>
       <code>getPrototypes</code>
       <code>getReturnType</code>
     </MixedMethodCall>
-    <PossiblyNullReference occurrences="2">
+    <PossiblyNullReference>
       <code>getEncoding</code>
       <code>getEncoding</code>
     </PossiblyNullReference>
   </file>
   <file src="test/TestAsset/SerializableTestClass.php">
-    <MissingConstructor occurrences="1">
+    <MissingConstructor>
       <code>$property</code>
     </MissingConstructor>
+    <PossiblyUnusedMethod>
+      <code>getProperty</code>
+    </PossiblyUnusedMethod>
   </file>
   <file src="test/TestAsset/TestClass.php">
-    <InvalidReturnStatement occurrences="1">
-      <code>['test1' =&gt; $this-&gt;value1, 'test2' =&gt; $this-&gt;value2, 'arg' =&gt; func_get_args()]</code>
+    <InvalidReturnStatement>
+      <code><![CDATA[['test1' => $this->value1, 'test2' => $this->value2, 'arg' => func_get_args()]]]></code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
       <code>struct</code>
     </InvalidReturnType>
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>(array) $array</code>
     </MixedArgumentTypeCoercion>
-    <MixedInferredReturnType occurrences="1">
+    <MixedInferredReturnType>
       <code>base64</code>
     </MixedInferredReturnType>
-    <RedundantCastGivenDocblockType occurrences="2">
+    <PossiblyUnusedMethod>
+      <code>__construct</code>
+      <code>base64</code>
+      <code>test1</code>
+      <code>test2</code>
+      <code>test3</code>
+      <code>test4</code>
+    </PossiblyUnusedMethod>
+    <PossiblyUnusedParam>
+      <code>$data</code>
+    </PossiblyUnusedParam>
+    <RedundantCastGivenDocblockType>
       <code>(array) $array</code>
       <code>(string) $string</code>
     </RedundantCastGivenDocblockType>
-    <UndefinedDocblockClass occurrences="3">
+    <UndefinedDocblockClass>
       <code>base64</code>
       <code>base64</code>
       <code>struct</code>
     </UndefinedDocblockClass>
   </file>
   <file src="test/TestAsset/TestClient.php">
-    <DeprecatedInterface occurrences="1">
+    <DeprecatedInterface>
       <code>TestClient</code>
     </DeprecatedInterface>
-    <PropertyNotSetInConstructor occurrences="2">
+    <PropertyNotSetInConstructor>
       <code>TestClient</code>
       <code>TestClient</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/TestRequest.php">
-    <PropertyNotSetInConstructor occurrences="3">
+    <PropertyNotSetInConstructor>
       <code>TestRequest</code>
       <code>TestRequest</code>
       <code>TestRequest</code>
     </PropertyNotSetInConstructor>
   </file>
   <file src="test/TestAsset/functions.php">
-    <MixedArgumentTypeCoercion occurrences="1">
+    <MixedArgumentTypeCoercion>
       <code>(array) $var1</code>
     </MixedArgumentTypeCoercion>
-    <RedundantCastGivenDocblockType occurrences="1">
+    <RedundantCastGivenDocblockType>
       <code>(array) $var1</code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="test/ValueTest.php">
-    <ForbiddenCode occurrences="1">
+    <ForbiddenCode>
       <code>var_dump($x)</code>
     </ForbiddenCode>
-    <MissingReturnType occurrences="1">
+    <MissingReturnType>
       <code>testMarshalBase64FromString</code>
     </MissingReturnType>
-    <MixedArgument occurrences="3">
-      <code>$val-&gt;getValue()</code>
-      <code>$val-&gt;getValue()</code>
-      <code>$val-&gt;getValue()</code>
+    <MixedArgument>
+      <code><![CDATA[$val->getValue()]]></code>
+      <code><![CDATA[$val->getValue()]]></code>
+      <code><![CDATA[$val->getValue()]]></code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="3">
+    <MixedArrayAccess>
       <code>$a[0]</code>
       <code>$a[1]</code>
       <code>$a[2]</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment>
       <code>$a</code>
       <code>$o2</code>
       <code>$received</code>
     </MixedAssignment>
-    <MixedMethodCall occurrences="1">
+    <MixedMethodCall>
       <code>getProperty</code>
     </MixedMethodCall>
-    <UnusedVariable occurrences="2">
+    <UnusedVariable>
       <code>$native</code>
       <code>$val</code>
     </UnusedVariable>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="1"
+    cacheDirectory="./.psalm-cache"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorLevel="1"
+    findUnusedPsalmSuppress="true"
+    findUnusedCode="true"
+    findUnusedBaselineEntry="true"
     errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>

--- a/src/AbstractValue.php
+++ b/src/AbstractValue.php
@@ -315,21 +315,27 @@ abstract class AbstractValue
 
         switch (static::getXmlRpcTypeByValue($value)) {
             case self::XMLRPC_TYPE_DATETIME:
+                /** @psalm-suppress MixedArgument */
                 return new Value\DateTime($value);
 
             case self::XMLRPC_TYPE_ARRAY:
+                /** @psalm-suppress MixedArgument */
                 return new Value\ArrayValue($value);
 
             case self::XMLRPC_TYPE_STRUCT:
+                /** @psalm-suppress MixedArgument */
                 return new Value\Struct($value);
 
             case self::XMLRPC_TYPE_INTEGER:
+                /** @psalm-suppress MixedArgument */
                 return new Value\Integer($value);
 
             case self::XMLRPC_TYPE_DOUBLE:
+                /** @psalm-suppress MixedArgument */
                 return new Value\Double($value);
 
             case self::XMLRPC_TYPE_BOOLEAN:
+                /** @psalm-suppress MixedArgument */
                 return new Value\Boolean($value);
 
             case self::XMLRPC_TYPE_NIL:
@@ -339,6 +345,7 @@ abstract class AbstractValue
                 // Fall through to the next case
             default:
                 // If type isn't identified (or identified as string), it treated as string
+                /** @psalm-suppress MixedArgument */
                 return new Value\Text($value);
         }
     }

--- a/src/Value/BigInteger.php
+++ b/src/Value/BigInteger.php
@@ -7,7 +7,7 @@ use Laminas\Math\BigInteger\BigInteger as BigIntegerMath;
 class BigInteger extends Integer
 {
     /**
-     * @param mixed $value
+     * @param string $value
      */
     public function __construct($value)
     {

--- a/src/Value/DateTime.php
+++ b/src/Value/DateTime.php
@@ -28,7 +28,7 @@ class DateTime extends AbstractScalar
      *
      * The value is in iso8601 format, minus any timezone information or dashes
      *
-     * @param mixed $value Integer of the unix timestamp or any string that can be parsed
+     * @param integer|string|\DateTime $value Integer of the unix timestamp or any string that can be parsed
      *                     to a unix timestamp using the PHP strtotime() function
      * @throws Exception\ValueException If unable to create a DateTime object from $value.
      */
@@ -54,7 +54,7 @@ class DateTime extends AbstractScalar
     /**
      * Return the value of this object as iso8601 dateTime value
      *
-     * @return int As a Unix timestamp
+     * @return string Formatted datetime
      */
     public function getValue()
     {

--- a/test/BigIntegerValueTest.php
+++ b/test/BigIntegerValueTest.php
@@ -43,8 +43,6 @@ class BigIntegerValueTest extends TestCase
         $this->useBigIntForI8Flag         = null;
     }
 
-    // BigInteger
-
     public function testBigIntegerGetValue(): void
     {
         $bigInteger = new BigInteger($this->bigIntValue);

--- a/test/ClientTest.php
+++ b/test/ClientTest.php
@@ -230,7 +230,7 @@ class ClientTest extends TestCase
              ->expects($this->exactly(2))
              ->method('getMethodSignature')
              ->with('test.method')
-             ->will($this->returnValue([['parameters' => ['int']]]));
+             ->willReturn([['parameters' => ['int']]]);
 
         $expect = 'test.method response';
         $this->setServerResponseTo($expect);
@@ -255,7 +255,7 @@ class ClientTest extends TestCase
              ->expects($this->exactly(1))
              ->method('getMethodSignature')
              ->with('date.method')
-             ->will($this->returnValue([['parameters' => ['dateTime.iso8601', 'string']]]));
+             ->willReturn([['parameters' => ['dateTime.iso8601', 'string']]]);
 
         $expects = 'date.method response';
         $this->setServerResponseTo($expects);
@@ -666,10 +666,10 @@ class ClientTest extends TestCase
              ->expects($this->exactly(2))
              ->method('getMethodSignature')
              ->with('get')
-             ->will($this->returnValue([
+             ->willReturn([
                  ['parameters' => ['int']],
                  ['parameters' => ['array']],
-             ]));
+             ]);
 
         $expectedResult = 'array';
         $this->setServerResponseTo($expectedResult);
@@ -762,11 +762,5 @@ class ClientTest extends TestCase
             ->disableOriginalClone()
             ->getMock();
         $this->xmlrpcClient->setIntrospector($this->mockedIntrospector);
-    }
-
-    public function mockHttpClient()
-    {
-        $this->mockedHttpClient = $this->createMock(HttpClient::class);
-        $this->xmlrpcClient->setHttpClient($this->mockedHttpClient);
     }
 }

--- a/test/ServerTest.php
+++ b/test/ServerTest.php
@@ -477,7 +477,7 @@ class ServerTest extends TestCase
         $mockedDefinition
             ->expects($this->once())
             ->method('getMethods')
-            ->will($this->returnValue(['bar' => $mockedMethod]));
+            ->willReturn(['bar' => $mockedMethod]);
         $this->server->loadFunctions($mockedDefinition);
     }
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This PR includes following changes:

- PHPUnit updated to 10.4 with config migrated to match. Deprecated method calls replaced.
- Psalm and its configuration updated to latest. Newly reported issues baselined while unused baseline entries removed.
- Tests that were always broken and skipped are now fixed and pass.
- Simplexml extension explicitly declared as dependency.

This component was not migrated to use strict types and is in pretty dire need of QA overhaul. Some version checks are looking for php 5.