### PR TITLE
Fix Value\Boolean serializing to empty tag when value is false

### DIFF
--- a/src/Value/Boolean.php
+++ b/src/Value/Boolean.php
@@ -9,7 +9,7 @@ use function filter_var;
 use const FILTER_VALIDATE_BOOLEAN;
 
 /**
- * @extends AbstractScalar<bool>
+ * @extends AbstractScalar<int<0, 1>>
  */
 final class Boolean extends AbstractScalar
 {
@@ -20,7 +20,7 @@ final class Boolean extends AbstractScalar
     public function __construct(bool|string|int $value)
     {
         $this->type  = self::XMLRPC_TYPE_BOOLEAN;
-        $this->value = filter_var($value, FILTER_VALIDATE_BOOLEAN);
+        $this->value = filter_var($value, FILTER_VALIDATE_BOOLEAN) ? 1 : 0;
     }
 
     /**
@@ -29,6 +29,6 @@ final class Boolean extends AbstractScalar
     #[Override]
     public function getValue(): bool
     {
-        return $this->value;
+        return $this->value === 1;
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Assuming the current release is 1.5.0, the next patch release is 1.5.1, the next minor is 1.6.0 and the next major is 2.0.0, The Current release branch will be `1.5.x`, the next minor branch will be `1.6.x`, and the next major branch will be `2.0.x`

Pick the target branch based on the following criteria:
  * Documentation improvement: Current release branch 1.5.x
  * Bugfix: Current release branch 1.5.x
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: Next minor 1.6.x
  * New feature, or refactor of existing code: Next minor 1.6.x
  * Backwards incompatible features and refactoring: Next major 2.0.x

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

This PR fixes a bug in `Laminas\XmlRpc\Value\Boolean` where passing a strict PHP boolean `false` serializes into an empty XML tag `<boolean></boolean>` instead of `<boolean>0</boolean>`. 

#### How to reproduce:
```php
use Laminas\XmlRpc\Value\Boolean;

$boolValue = new Boolean(false);
echo $boolValue->saveXml(); 
// Actual output: <value><boolean></boolean></value>
```

What I expected to happen:
According to the XML-RPC specification, a boolean value must strictly be represented as 0 or 1. Passing PHP false should yield <value><boolean>0</boolean></value>.

What actually happened:
An empty <boolean></boolean> tag was generated, causing remote XML-RPC servers (such as Python's standard xmlrpc.client / Odoo ERP) to fail parsing with a TypeError: bad boolean value.

Solution:
By explicitly casting the filtered value to an integer (int) inside the constructor, it ensures the internal $this->value correctly holds 0 or 1 as stated in the docblock, restoring specification conformity.

Fixes #67

<!--

Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding documentation?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE NEXT MINOR BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE CURRENT RELEASE BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE NEXT MINOR BRANCH OR THE NEXT MAJOR IF BC WILL BE BROKEN
-->
